### PR TITLE
AutocompleteコンポーネントとCSvgIconコンポーネントを作る

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "jupiter",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jupiter",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "devDependencies": {
         "@histoire/plugin-vue": "^0.12.4",
+        "@mdi/js": "^7.1.96",
         "@rushstack/eslint-patch": "^1.1.4",
         "@testing-library/vue": "^6.6.1",
         "@types/jsdom": "^20.0.1",
@@ -410,6 +411,12 @@
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
+    },
+    "node_modules/@mdi/js": {
+      "version": "7.1.96",
+      "resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.1.96.tgz",
+      "integrity": "sha512-wlrJs6Ryhaa5CqhK3FjTfMRnb/s7HeLkKMFqwQySkK86cdN1TGdzpSM3O4tsmzCA1dYBeTbXvOwSE/Y42cUrvA==",
+      "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@histoire/plugin-vue": "^0.12.4",
+    "@mdi/js": "^7.1.96",
     "@rushstack/eslint-patch": "^1.1.4",
     "@testing-library/vue": "^6.6.1",
     "@types/jsdom": "^20.0.1",

--- a/src/components/dataDisplay/CSvgIcon.story.vue
+++ b/src/components/dataDisplay/CSvgIcon.story.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import {reactive} from "vue";
+import { mdiPlus, mdiMinus, mdiAccount, mdiAlert, mdiClose, mdiTab } from "@mdi/js";
+import CSvgIcon from "@/components/dataDisplay/CSvgIcon.vue";
+import CCenter from "@/components/layout/CCenter.vue";
+import CCluster from "@/components/layout/CCluster.vue";
+import CButton from "@/components/form/CButton.vue";
+
+const data: {
+    icon: string
+    size: "small" | "medium" | "large"
+} = reactive({
+    icon: mdiPlus,
+    size: 'medium',
+})
+</script>
+
+<template>
+<Story
+    title="Data Display / CSvgIcon"
+    :layout="{ type: 'grid', width: '100%' }"
+>
+    <Variant title="基本" auto-props-disabled>
+        <c-center intrinsic>
+            <c-svg-icon :icon="data.icon" :size="data.size"/>
+        </c-center>
+        <template #controls>
+            <HstSelect
+            v-model="data.icon"
+            title="icon"
+            :options="[
+                {value: mdiPlus, label: 'mdiPlus'},
+                {value: mdiMinus, label: 'mdiMinus'},
+                {value: mdiAccount, label: 'mdiAccount'},
+                {value: mdiAlert, label: 'mdiAlert'},
+            ]"
+            />
+            <HstSelect
+            v-model="data.size"
+            title="size"
+            :options="[
+                {value: 'small', label: 'small'},
+                {value: 'medium', label: 'medium'},
+                {value: 'large', label: 'large'},
+            ]"
+            />
+        </template>
+    </Variant>
+    <Variant title="ボタンに内包れたアイコン" auto-props-disabled>
+        <c-center intrinsic>
+            <c-button>
+                <c-cluster space="0">
+                    <c-svg-icon :icon="mdiClose"/>
+                    キャンセル
+                </c-cluster>
+            </c-button>
+        </c-center>
+    </Variant>
+    <Variant title="tabindex" auto-props-disabled>
+        <c-center intrinsic>
+            <c-svg-icon tabindex="0" :icon="mdiTab"/>
+        </c-center>
+    </Variant>
+</Story>
+</template>
+
+<docs lang="md">
+# CSvgIcon
+material design iconなど、要素svgでアイコンを表示するためのコンポーネントです。
+
+## Props
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| icon | string | '' | iconのpathを指定します |
+| size | "small"/"medium"/"large" | "medium" | アイコンのサイズを指定します |
+
+
+## Slots
+
+| Name | Props (if scoped) | Description |
+| --- | --- | --- |
+| - | - | このコンポーネント独自のSlotはありません |
+
+## Events
+
+| Name | Parameters | Description |
+| --- | --- | --- |
+| - | - | このコンポーネント独自のイベントはありません |
+</docs>

--- a/src/components/dataDisplay/CSvgIcon.story.vue
+++ b/src/components/dataDisplay/CSvgIcon.story.vue
@@ -46,10 +46,10 @@ const data: {
             />
         </template>
     </Variant>
-    <Variant title="ボタンに内包れたアイコン" auto-props-disabled>
+    <Variant title="ボタンに内包されたアイコン" auto-props-disabled>
         <c-center intrinsic>
             <c-button>
-                <c-cluster space="0">
+                <c-cluster space="0" align="center">
                     <c-svg-icon :icon="mdiClose"/>
                     キャンセル
                 </c-cluster>

--- a/src/components/dataDisplay/CSvgIcon.vue
+++ b/src/components/dataDisplay/CSvgIcon.vue
@@ -9,16 +9,16 @@ const props = withDefaults(defineProps<{
     size: 'medium',
 })
 
-const sizeClass = computed(() => {
-    if(props.size === 'small') return '16'
-    if(props.size === 'large') return '30'
-    return '20'
+const length = computed(() => {
+    if(props.size === 'small') return '0.75em'
+    if(props.size === 'large') return '2em'
+    return '1em'
 })
 
 </script>
 
 <template>
-<svg :width="sizeClass" :height="sizeClass" viewBox="0 0 24 24">
+<svg :width="length" :height="length" viewBox="0 0 24 24">
     <path fill="currentColor" :d="icon"/>
 </svg>
 </template>

--- a/src/components/dataDisplay/CSvgIcon.vue
+++ b/src/components/dataDisplay/CSvgIcon.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = withDefaults(defineProps<{
+    icon: string
+    size?: "small" | "medium" | "large"
+}>(), {
+    icon: '',
+    size: 'medium',
+})
+
+const sizeClass = computed(() => {
+    if(props.size === 'small') return '16'
+    if(props.size === 'large') return '30'
+    return '20'
+})
+
+</script>
+
+<template>
+<svg :width="sizeClass" :height="sizeClass" viewBox="0 0 24 24">
+    <path fill="currentColor" :d="icon"/>
+</svg>
+</template>

--- a/src/components/form/CAutocomplete.story.vue
+++ b/src/components/form/CAutocomplete.story.vue
@@ -1,0 +1,292 @@
+<script setup lang="ts">
+import {reactive} from "vue";
+import CBox from "@/components/layout/CBox.vue";
+import CAutocomplete from "@/components/form/CAutocomplete.vue";
+
+interface 名簿型 {
+    id: string
+    姓: string
+    名: string
+}
+
+const data: {
+    入力値: string
+    名簿: 名簿型[]
+    ラベル: string
+    スタイル: 'filled'|'outlined'|'underlined'
+} = reactive({
+    入力値: '',
+    名簿: [
+        {
+            id: '1',
+            姓: '田中',
+            名: '太郎',
+        },
+        {
+            id: '2',
+            姓: '田中',
+            名: '一郎',
+        },
+        {
+            id: '3',
+            姓: '鈴木',
+            名: '花子',
+        },
+        {
+            id: '4',
+            姓: 'JOHNSON',
+            名: 'MARY',
+        },
+    ],
+    ラベル: 'ラベル',
+    スタイル: 'filled',
+})
+
+const clearable: {
+    選択された値: string
+    スタイル: 'filled'|'outlined'|'underlined'
+} = reactive({
+    選択された値: '1',
+    スタイル: 'filled'
+})
+
+const iserror: {
+    選択された値: string
+    スタイル: 'filled'|'outlined'|'underlined'
+} = reactive({
+    選択された値: '1',
+    スタイル: 'filled'
+})
+
+const disabled: {
+    選択された値: string
+    スタイル: 'filled'|'outlined'|'underlined'
+} = reactive({
+    選択された値: '1',
+    スタイル: 'filled'
+})
+
+const readonly: {
+    選択された値: string
+    スタイル: 'filled'|'outlined'|'underlined'
+} = reactive({
+    選択された値: '1',
+    スタイル: 'filled'
+})
+
+const 絞り込み = (item:名簿型, searchText:string) => {
+    const keyword = searchText.toUpperCase()
+    if(item.姓.toUpperCase().indexOf(keyword) > -1) return true
+    return item.名.toUpperCase().indexOf(keyword) > -1
+}
+</script>
+
+<template>
+<Story
+    title="Form / CAutocomplete"
+    :layout="{ type: 'grid', width: 500 }"
+>
+<Variant title="基本" auto-props-disabled>
+        <c-box padding="large">
+            <c-autocomplete
+            v-model="data.入力値"
+            :items="data.名簿"
+            item-value="id"
+            :filter="絞り込み"
+            :label="data.ラベル"
+            placeholder="placeholder"
+            clearable
+            :variant="data.スタイル"
+            id="filled"
+            >
+                <template v-slot:selection="{item}">
+                    {{ item.姓 }} {{ item.名 }}
+                </template>
+                <template v-slot:item="{item}">
+                    {{ item.姓 }} {{ item.名 }}
+                </template>
+                <template v-slot:empty>
+                    一致するものはありませんでした
+                </template>
+            </c-autocomplete>    
+        </c-box>
+        <template #controls>
+            <HstText v-model="data.入力値" title="modelValue"/>
+            <HstJson
+                v-model="data.名簿"
+                title="items"
+            />
+            <HstText v-model="data.ラベル" title="label"/>
+            <HstSelect
+            v-model="data.スタイル"
+            title="variant"
+            :options="[
+                {value: 'filled', label: 'filled'},
+                {value: 'outlined', label: 'outlined'},
+                {value: 'underlined', label: 'underlined'},
+            ]"
+            />
+        </template>
+    </Variant>
+    <Variant title="clearable" auto-props-disabled>
+        <c-box padding="large">
+            <c-autocomplete
+            v-model="clearable.選択された値"
+            :items="data.名簿"
+            item-value="id"
+            :filter="絞り込み"
+            :variant="clearable.スタイル"
+            placeholder="入力"
+            clearable
+            >
+                <template v-slot:selection="{item}">
+                    {{ item.姓 }} {{ item.名 }}
+                </template>
+                <template v-slot:item="{item}">
+                    {{ item.姓 }} {{ item.名 }}
+                </template>
+            </c-autocomplete>
+        </c-box>
+        <template #controls>
+            <HstSelect
+            v-model="clearable.スタイル"
+            title="variant"
+            :options="[
+                {value: 'filled', label: 'filled'},
+                {value: 'outlined', label: 'outlined'},
+                {value: 'underlined', label: 'underlined'},
+            ]"
+            />
+        </template>
+    </Variant>
+    <Variant title="非活性" auto-props-disabled>
+        <c-box padding="large">
+            <c-autocomplete
+            v-model="disabled.選択された値"
+            :items="data.名簿"
+            item-value="id"
+            :filter="絞り込み"
+            :variant="disabled.スタイル"
+            placeholder="入力"
+            disabled
+            >
+                <template v-slot:selection="{item}">
+                    {{ item.姓 }} {{ item.名 }}
+                </template>
+                <template v-slot:item="{item}">
+                    {{ item.姓 }} {{ item.名 }}
+                </template>
+            </c-autocomplete>
+        </c-box>
+        <template #controls>
+            <HstSelect
+            v-model="disabled.スタイル"
+            title="variant"
+            :options="[
+                {value: 'filled', label: 'filled'},
+                {value: 'outlined', label: 'outlined'},
+                {value: 'underlined', label: 'underlined'},
+            ]"
+            />
+        </template>
+    </Variant>
+    <Variant title="読み取り専用" auto-props-disabled>
+        <c-box padding="large">
+            <c-autocomplete
+            v-model="readonly.選択された値"
+            :items="data.名簿"
+            item-value="id"
+            :filter="絞り込み"
+            :variant="readonly.スタイル"
+            readonly
+            >
+                <template v-slot:selection="{item}">
+                    {{ item.姓 }} {{ item.名 }}
+                </template>
+                <template v-slot:item="{item}">
+                    {{ item.姓 }} {{ item.名 }}
+                </template>
+            </c-autocomplete>
+        </c-box>
+        <template #controls>
+            <HstSelect
+            v-model="readonly.スタイル"
+            title="variant"
+            :options="[
+                {value: 'filled', label: 'filled'},
+                {value: 'outlined', label: 'outlined'},
+                {value: 'underlined', label: 'underlined'},
+            ]"
+            />
+        </template>
+    </Variant>
+    <Variant title="警告" auto-props-disabled>
+        <c-box padding="large">
+            <c-autocomplete
+            v-model="iserror.選択された値"
+            :items="data.名簿"
+            item-value="id"
+            :filter="絞り込み"
+            :variant="iserror.スタイル"
+            placeholder="入力"
+            is-error
+            >
+                <template v-slot:selection="{item}">
+                    {{ item.姓 }} {{ item.名 }}
+                </template>
+                <template v-slot:item="{item}">
+                    {{ item.姓 }} {{ item.名 }}
+                </template>
+                <template v-slot:errorMessage>
+                    名前を入力してください
+                </template>
+            </c-autocomplete>
+        </c-box>
+        <template #controls>
+            <HstSelect
+            v-model="iserror.スタイル"
+            title="variant"
+            :options="[
+                {value: 'filled', label: 'filled'},
+                {value: 'outlined', label: 'outlined'},
+                {value: 'underlined', label: 'underlined'},
+            ]"
+            />
+        </template>
+    </Variant>
+</Story>
+</template>
+
+<docs lang="md">
+# CAutocomplete
+入力補完機能のついたフォームコンポーネントです。
+
+## Props
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| modelValue | any | null | コンポーネントのv-model値です |
+| items | any[] | [] | オブジェクトの配列、または文字列の配列を指定できます。オブジェクトの配列の場合、itemValueを使用することで、キーを変更できます。 |
+| itemValue | string | 'value' | itemsがオブジェクト配列の場合、識別するためのキーを指定することができます |
+| filter | (item: any, searchText: string) => boolean | undefined | 絞り込みを行うための関数を指定します |
+| label | string | '' | ラベルに設定するテキストを指定します |
+| variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
+| readonly | boolean | false | 読み取り専用かどうか |
+| isError | boolean | false | コンポーネントをエラー状態にするかどうか |
+| clearable | boolean | false | 入力したテキストをクリアするボタンを追加するかどうか |
+
+## Slots
+
+| Name | Props (if scoped) | Description |
+| --- | --- | --- |
+| selection | item | 選択された値の表示方法をカスタムできます |
+| item | item | ドロップダウンリストの各項目の表示方法をカスタムできます |
+| empty |  | ドロップダウンリストに一件も表示されない時に使用します |
+| errorMessage |  | エラーの時のメッセージを表示する時に使用します |
+
+## Events
+
+| Name | Parameters | Description |
+| --- | --- | --- |
+| update:modelValue | - | コンポーネントのv-modelが変更されたときに発行されるイベントです |
+</docs>

--- a/src/components/form/CAutocomplete.story.vue
+++ b/src/components/form/CAutocomplete.story.vue
@@ -44,33 +44,41 @@ const data: {
 
 const clearable: {
     選択された値: string
+    clearable: boolean
     スタイル: 'filled'|'outlined'|'underlined'
 } = reactive({
     選択された値: '1',
+    clearable: true,
     スタイル: 'filled'
 })
 
 const iserror: {
     選択された値: string
+    isError: boolean
     スタイル: 'filled'|'outlined'|'underlined'
 } = reactive({
     選択された値: '1',
+    isError: true,
     スタイル: 'filled'
 })
 
 const disabled: {
     選択された値: string
+    disabled: boolean
     スタイル: 'filled'|'outlined'|'underlined'
 } = reactive({
     選択された値: '1',
+    disabled: true,
     スタイル: 'filled'
 })
 
 const readonly: {
     選択された値: string
+    readonly: boolean
     スタイル: 'filled'|'outlined'|'underlined'
 } = reactive({
     選択された値: '1',
+    readonly: true,
     スタイル: 'filled'
 })
 
@@ -137,7 +145,7 @@ const 絞り込み = (item:名簿型, searchText:string) => {
             :filter="絞り込み"
             :variant="clearable.スタイル"
             placeholder="入力"
-            clearable
+            :clearable="clearable.clearable"
             >
                 <template v-slot:selection="{item}">
                     {{ item.姓 }} {{ item.名 }}
@@ -148,6 +156,10 @@ const 絞り込み = (item:名簿型, searchText:string) => {
             </c-autocomplete>
         </c-box>
         <template #controls>
+            <HstCheckbox
+                v-model="clearable.clearable"
+                title="clearable"
+            />
             <HstSelect
             v-model="clearable.スタイル"
             title="variant"
@@ -168,7 +180,7 @@ const 絞り込み = (item:名簿型, searchText:string) => {
             :filter="絞り込み"
             :variant="disabled.スタイル"
             placeholder="入力"
-            disabled
+            :disabled="disabled.disabled"
             >
                 <template v-slot:selection="{item}">
                     {{ item.姓 }} {{ item.名 }}
@@ -179,6 +191,10 @@ const 絞り込み = (item:名簿型, searchText:string) => {
             </c-autocomplete>
         </c-box>
         <template #controls>
+            <HstCheckbox
+                v-model="disabled.disabled"
+                title="disabled"
+            />
             <HstSelect
             v-model="disabled.スタイル"
             title="variant"
@@ -198,7 +214,7 @@ const 絞り込み = (item:名簿型, searchText:string) => {
             item-value="id"
             :filter="絞り込み"
             :variant="readonly.スタイル"
-            readonly
+            :readonly="readonly.readonly"
             >
                 <template v-slot:selection="{item}">
                     {{ item.姓 }} {{ item.名 }}
@@ -209,6 +225,10 @@ const 絞り込み = (item:名簿型, searchText:string) => {
             </c-autocomplete>
         </c-box>
         <template #controls>
+            <HstCheckbox
+                v-model="readonly.readonly"
+                title="readonly"
+            />
             <HstSelect
             v-model="readonly.スタイル"
             title="variant"
@@ -229,7 +249,7 @@ const 絞り込み = (item:名簿型, searchText:string) => {
             :filter="絞り込み"
             :variant="iserror.スタイル"
             placeholder="入力"
-            is-error
+            :is-error="iserror.isError"
             >
                 <template v-slot:selection="{item}">
                     {{ item.姓 }} {{ item.名 }}
@@ -243,6 +263,10 @@ const 絞り込み = (item:名簿型, searchText:string) => {
             </c-autocomplete>
         </c-box>
         <template #controls>
+            <HstCheckbox
+                v-model="iserror.isError"
+                title="isError"
+            />
             <HstSelect
             v-model="iserror.スタイル"
             title="variant"

--- a/src/components/form/CAutocomplete.story.vue
+++ b/src/components/form/CAutocomplete.story.vue
@@ -9,9 +9,29 @@ interface 名簿型 {
     名: string
 }
 
-const data: {
+const string: {
+    入力値: string
+    血液型: string[]
+    ラベル: string
+    スタイル: 'filled'|'outlined'|'underlined'
+    placeholder: string
+} = reactive({
+    入力値: '',
+    血液型: [
+    'A型',
+    'B型',
+    'O型',
+    'AB型',
+    ],
+    ラベル: 'ラベル',
+    スタイル: 'filled',
+    placeholder: '入力してください'
+})
+
+const object: {
     入力値: string
     名簿: 名簿型[]
+    識別子: string
     ラベル: string
     スタイル: 'filled'|'outlined'|'underlined'
     placeholder: string
@@ -39,6 +59,7 @@ const data: {
             名: 'MARY',
         },
     ],
+    識別子: 'id',
     ラベル: 'ラベル',
     スタイル: 'filled',
     placeholder: '入力してください'
@@ -84,7 +105,11 @@ const readonly: {
     スタイル: 'filled'
 })
 
-const 絞り込み = (item:名簿型, searchText:string) => {
+const 文字列配列の絞り込み = (item:string, searchText:string) => {
+    const keyword = searchText.toUpperCase()
+    return item.toUpperCase().indexOf(keyword) > -1
+}
+const オブジェクト配列の絞り込み = (item:名簿型, searchText:string) => {
     const keyword = searchText.toUpperCase()
     if(item.姓.toUpperCase().indexOf(keyword) > -1) return true
     return item.名.toUpperCase().indexOf(keyword) > -1
@@ -96,38 +121,28 @@ const 絞り込み = (item:名簿型, searchText:string) => {
     title="Form / CAutocomplete"
     :layout="{ type: 'grid', width: 500 }"
 >
-<Variant title="基本" auto-props-disabled>
+<Variant title="文字列の配列の場合" auto-props-disabled>
         <c-box padding="large">
             <c-autocomplete
-            v-model="data.入力値"
-            :items="data.名簿"
-            item-value="id"
-            :filter="絞り込み"
-            :label="data.ラベル"
-            :placeholder="data.placeholder"
-            :variant="data.スタイル"
-            id="filled"
+            v-model="string.入力値"
+            :items="string.血液型"
+            :filter="文字列配列の絞り込み"
+            :label="string.ラベル"
+            :placeholder="string.placeholder"
+            :variant="string.スタイル"
+            id="string"
             >
-                <template v-slot:selection="{item}">
-                    {{ item.姓 }} {{ item.名 }}
-                </template>
-                <template v-slot:item="{item}">
-                    {{ item.姓 }} {{ item.名 }}
-                </template>
-                <template v-slot:empty>
-                    一致するものはありませんでした
-                </template>
             </c-autocomplete>    
         </c-box>
         <template #controls>
-            <HstText v-model="data.入力値" title="modelValue"/>
+            <HstText v-model="string.入力値" title="modelValue"/>
             <HstJson
-                v-model="data.名簿"
+                v-model="string.血液型"
                 title="items"
             />
-            <HstText v-model="data.ラベル" title="label"/>
+            <HstText v-model="string.ラベル" title="label"/>
             <HstSelect
-            v-model="data.スタイル"
+            v-model="string.スタイル"
             title="variant"
             :options="[
                 {value: 'filled', label: 'filled'},
@@ -135,16 +150,56 @@ const 絞り込み = (item:名簿型, searchText:string) => {
                 {value: 'underlined', label: 'underlined'},
             ]"
             />
-            <HstText v-model="data.placeholder" title="placeholder"/>
+            <HstText v-model="string.placeholder" title="placeholder"/>
+        </template>
+    </Variant>
+    <Variant title="オブジェクト配列の場合" auto-props-disabled>
+        <c-box padding="large">
+            <c-autocomplete
+            v-model="object.入力値"
+            :items="object.名簿"
+            :item-value="object.識別子"
+            :filter="オブジェクト配列の絞り込み"
+            :label="object.ラベル"
+            :placeholder="object.placeholder"
+            :variant="object.スタイル"
+            id="object"
+            >
+                <template v-slot:selection="{item}">
+                    {{ item.姓 }} {{ item.名 }}
+                </template>
+                <template v-slot:item="{item}">
+                    {{ item.姓 }} {{ item.名 }}
+                </template>
+            </c-autocomplete>    
+        </c-box>
+        <template #controls>
+            <HstText v-model="object.入力値" title="modelValue"/>
+            <HstJson
+                v-model="object.名簿"
+                title="items"
+            />
+            <HstText v-model="object.識別子" title="itemValue"/>
+            <HstText v-model="object.ラベル" title="label"/>
+            <HstSelect
+            v-model="object.スタイル"
+            title="variant"
+            :options="[
+                {value: 'filled', label: 'filled'},
+                {value: 'outlined', label: 'outlined'},
+                {value: 'underlined', label: 'underlined'},
+            ]"
+            />
+            <HstText v-model="object.placeholder" title="placeholder"/>
         </template>
     </Variant>
     <Variant title="clearable" auto-props-disabled>
         <c-box padding="large">
             <c-autocomplete
             v-model="clearable.選択された値"
-            :items="data.名簿"
+            :items="object.名簿"
             item-value="id"
-            :filter="絞り込み"
+            :filter="オブジェクト配列の絞り込み"
             :variant="clearable.スタイル"
             placeholder="入力"
             :clearable="clearable.clearable"
@@ -177,9 +232,9 @@ const 絞り込み = (item:名簿型, searchText:string) => {
         <c-box padding="large">
             <c-autocomplete
             v-model="disabled.選択された値"
-            :items="data.名簿"
+            :items="object.名簿"
             item-value="id"
-            :filter="絞り込み"
+            :filter="オブジェクト配列の絞り込み"
             :variant="disabled.スタイル"
             placeholder="入力"
             :disabled="disabled.disabled"
@@ -212,9 +267,9 @@ const 絞り込み = (item:名簿型, searchText:string) => {
         <c-box padding="large">
             <c-autocomplete
             v-model="readonly.選択された値"
-            :items="data.名簿"
+            :items="object.名簿"
             item-value="id"
-            :filter="絞り込み"
+            :filter="オブジェクト配列の絞り込み"
             :variant="readonly.スタイル"
             :readonly="readonly.readonly"
             >
@@ -246,9 +301,9 @@ const 絞り込み = (item:名簿型, searchText:string) => {
         <c-box padding="large">
             <c-autocomplete
             v-model="iserror.選択された値"
-            :items="data.名簿"
+            :items="object.名簿"
             item-value="id"
-            :filter="絞り込み"
+            :filter="オブジェクト配列の絞り込み"
             :variant="iserror.スタイル"
             placeholder="入力"
             :is-error="iserror.isError"
@@ -293,13 +348,13 @@ const 絞り込み = (item:名簿型, searchText:string) => {
 | --- | --- | --- | --- |
 | modelValue | any | null | コンポーネントのv-model値です |
 | items | any[] | [] | オブジェクトの配列、または文字列の配列を指定できます。オブジェクトの配列の場合、itemValueを使用することで、キーを変更できます。 |
-| itemValue | string | 'value' | itemsがオブジェクト配列の場合、識別するためのキーを指定することができます |
+| itemValue | string | '' | itemsがオブジェクト配列の場合、識別するためのキーを指定することができます |
 | filter | (item: any, searchText: string) => boolean | undefined | 絞り込みを行うための関数を指定します |
 | label | string | '' | ラベルに設定するテキストを指定します |
 | variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
-| readonly | boolean | false | 読み取り専用かどうか |
-| isError | boolean | false | コンポーネントをエラー状態にするかどうか |
-| clearable | boolean | false | 入力したテキストをクリアするボタンを追加するかどうか |
+| readonly | boolean | false | 読み取り専用にする場合は指定します |
+| isError | boolean | false | コンポーネントをエラー状態にする場合は指定します |
+| clearable | boolean | false | 入力したテキストをクリアするボタンを追加する場合は指定します |
 
 ## Slots
 

--- a/src/components/form/CAutocomplete.story.vue
+++ b/src/components/form/CAutocomplete.story.vue
@@ -14,6 +14,7 @@ const data: {
     名簿: 名簿型[]
     ラベル: string
     スタイル: 'filled'|'outlined'|'underlined'
+    placeholder: string
 } = reactive({
     入力値: '',
     名簿: [
@@ -40,6 +41,7 @@ const data: {
     ],
     ラベル: 'ラベル',
     スタイル: 'filled',
+    placeholder: '入力してください'
 })
 
 const clearable: {
@@ -102,8 +104,7 @@ const 絞り込み = (item:名簿型, searchText:string) => {
             item-value="id"
             :filter="絞り込み"
             :label="data.ラベル"
-            placeholder="placeholder"
-            clearable
+            :placeholder="data.placeholder"
             :variant="data.スタイル"
             id="filled"
             >
@@ -134,6 +135,7 @@ const 絞り込み = (item:名簿型, searchText:string) => {
                 {value: 'underlined', label: 'underlined'},
             ]"
             />
+            <HstText v-model="data.placeholder" title="placeholder"/>
         </template>
     </Variant>
     <Variant title="clearable" auto-props-disabled>

--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -1,0 +1,147 @@
+<script setup lang="ts">
+import { computed, reactive, watchEffect } from 'vue'
+import { mdiMenuDown, mdiMenuUp, mdiClose } from '@mdi/js';
+import CSvgIcon from '@/components/dataDisplay/CSvgIcon.vue';
+
+const props = withDefaults(defineProps<{
+    modelValue: any
+    items: Array<any>
+    itemValue?: string
+    placeholder?: string
+    filter: (item: any, searchText: string) => boolean
+    readonly?: boolean
+    disabled?: boolean
+    isError?: boolean
+    clearable?: boolean
+}>(), {
+    placeholder: '',
+    readonly: false,
+    disabled: false,
+    isError: false,
+    clearable: false,
+})
+
+const emits = defineEmits<{
+    (e: 'update:modelValue', value: any): void
+}>()
+
+const data: {
+    isActive: boolean
+    isHover: boolean
+    inputText: string
+} = reactive({
+    isActive: false,
+    isHover: false,
+    inputText: '',
+})
+
+const fieldClass = computed(() => {
+    return [
+        'flex items-center bg-white whitespace-nowrap pl-3 pr-7 w-full border rounded focus:ring opacity-100 ',
+        props.disabled ? 'pr-3 bg-gray-100 border-none text-zinc-400 cursor-not-allowed': '',
+        props.isError ? 'border-red-700 text-red-700' : 'border-gray-400 text-gray-700',
+        props.clearable ? 'pr-14' : '',
+    ]
+})
+
+const dropdownListItems = computed(() => {
+    if (!props.items) return []
+    if (!data.inputText) return props.items
+    return props.items.filter((item)=>props.filter(item, data.inputText))
+})
+
+const selectionItem = computed(() => {
+    if(!props.itemValue && props.modelValue) return props.items.filter(item =>{ return item === props.modelValue})[0]
+    if(!props.itemValue && !props.modelValue) return ''
+    if(props.modelValue) return props.items.filter(item => {
+        if(props.itemValue) return item[props.itemValue] == props.modelValue
+    })[0]
+
+    return {}
+})
+
+const clearIconDisplay = computed(() => {
+    return props.clearable && !props.disabled && !props.readonly && (data.inputText!=='' || Object.keys(selectionItem.value).length)
+})
+
+const dropdownIconDisplay = computed(() => {
+    return !props.disabled && !props.readonly
+})
+
+const dropdownListDisplay = computed(() => {
+    return data.isActive && !props.readonly
+})
+
+const selectionSlotDisplay = computed(() => {
+    if (!props.modelValue) return false
+    if(!props.items) return false
+    if (props.items.length === 0) return false 
+    return props.itemValue ? Object.keys(selectionItem).length : selectionItem.value!==''
+})
+
+const liClass= (item:any) => {
+    if(props.itemValue) return item[props.itemValue]===selectionItem.value[props.itemValue]?'bg-blue-50 text-blue-700':''
+    return item === selectionItem.value ? 'bg-blue-50 text-blue-700':''
+}
+
+const selectItem = (option: any) => {
+    if(props.itemValue) emits('update:modelValue', option[props.itemValue])
+    if(!props.itemValue) emits('update:modelValue', option)
+    data.isActive = false
+    data.inputText = ''
+}
+
+const openDropdownList = () => {
+    data.isActive = true
+}
+
+const closeDropdownList = () => {
+    if (data.isHover) return
+    data.isActive = false
+}
+
+const toggleDropdownList = () => {
+    data.isActive = !data.isActive
+}
+
+const clear = () => {
+    if(props.modelValue) emits('update:modelValue', '')
+    if(data.inputText) data.inputText = ''
+}
+
+watchEffect(() => {
+    if(data.inputText) emits('update:modelValue', '')
+})
+
+</script>
+<template>
+<div @mouseover="data.isHover = true" @mouseleave="data.isHover = false" class="relative text-base w-auto">
+    <div :class="fieldClass">
+        <slot v-if="selectionSlotDisplay" name="selection" :item="selectionItem"/>
+        <input 
+        v-model="data.inputText" 
+        :placeholder="modelValue ? '' : placeholder"
+        @focus="openDropdownList" 
+        @blur="closeDropdownList"
+        @keyup.delete="clear"
+        class="py-2 w-full focus:outline-none opacity-100"
+        :disabled="disabled"
+        :readonly="readonly">
+    </div>
+    <c-svg-icon v-show="clearIconDisplay" :path="mdiClose" @click="clear" class="absolute top-2 right-7 text-gray-500" />
+    <c-svg-icon v-show="dropdownIconDisplay" :path="data.isActive ? mdiMenuUp : mdiMenuDown" @click="toggleDropdownList" class="absolute top-2 right-1" :class="isError ? 'text-red-700':'text-gray-500'"/>
+    <div v-show="dropdownListDisplay" class="absolute left-0 top-full z-50 w-full">
+        <ul class="overflow-auto divide-y-2 divide-gray-100 rounded-b bg-white shadow-lg z-50 max-h-60">
+            <template v-if="dropdownListItems.length > 0">
+                <li v-for="item in dropdownListItems" :key="itemValue?item[itemValue]:item" @click.stop="selectItem(item)" :class="liClass(item)" class="py-2 px-3 min-w-full text-gray-700 cursor-pointer hover:bg-gray-100">
+                <slot name="item" :item="item"/>
+            </li>
+            </template>
+            <li v-if="dropdownListItems.length === 0" @click="data.isActive=false" class="p-2 min-w-full text-xs text-gray-500">
+                一致するものはありません
+            </li>
+        </ul>
+    </div>
+</div>
+
+</template>

--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { computed, reactive, watchEffect } from 'vue'
+import { computed, reactive, useSlots, watchEffect } from 'vue'
 import { mdiMenuDown, mdiMenuUp, mdiClose } from '@mdi/js';
 import CSvgIcon from '@/components/dataDisplay/CSvgIcon.vue';
+
+const slots = useSlots()
 
 const props = withDefaults(defineProps<{
     modelValue: any
@@ -14,7 +16,7 @@ const props = withDefaults(defineProps<{
     isError?: boolean
     clearable?: boolean
 }>(), {
-    itemValue: 'value',
+    itemValue: '',
     label: '',
     variant: 'filled',
     readonly: false,
@@ -143,7 +145,9 @@ watchEffect(() => {
 <div @mouseover="data.isHover = true" @mouseleave="data.isHover = false" class="relative text-base w-auto">
     <fieldset v-bind="$attrs" :class="fieldClass">
         <div class="pb-1 pt-4 whitespace-nowrap group-read-only:text-gray-500 group-disabled:text-gray-500">
-            <slot v-if="selectionSlotDisplay" name="selection" :item="selectionItem"/>
+            <slot v-if="selectionSlotDisplay" name="selection" :item="selectionItem">
+                {{ typeof selectionItem === "object" ? selectionItem[itemValue] : selectionItem }}
+            </slot>
         </div>
         <input 
             v-model="data.inputText"
@@ -167,18 +171,21 @@ watchEffect(() => {
             <ul class="overflow-auto divide-y-2 divide-gray-100 rounded-b bg-white shadow-lg z-50 max-h-60">
                 <template v-if="dropdownListItems.length > 0">
                     <li v-for="item in dropdownListItems" :key="itemValue?item[itemValue]:item" @click.stop="selectItem(item)" :class="liClass(item)" class="py-2 px-3 min-w-full text-gray-700 cursor-pointer hover:bg-gray-100">
-                    <slot name="item" :item="item"/>
+                    <slot name="item" :item="item">
+                        {{ typeof item === "object" ? item[itemValue] : item }}
+                    </slot>
                 </li>
                 </template>
                 <li v-if="dropdownListItems.length === 0" @click="data.isActive=false" class="p-2 min-w-full text-xs text-gray-500">
-                    <slot name="empty"/>
+                    <slot name="empty">
+                        一件もデータがありません
+                    </slot>
                 </li>
             </ul>
         </div>
     </fieldset>
 </div>
-<div v-show="isError" class="text-xs text-[var(--jupiter-danger-text)] pt-1">
+<div v-if="slots.errorMessage" class="text-xs text-[var(--jupiter-danger-text)] pt-1">
     <slot name="errorMessage"/>
 </div>
-
 </template>

--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -185,7 +185,7 @@ watchEffect(() => {
         </div>
     </fieldset>
 </div>
-<div v-if="slots.errorMessage" class="text-xs text-[var(--jupiter-danger-text)] pt-1">
+<div v-if="isError && slots.errorMessage" class="text-xs text-[var(--jupiter-danger-text)] pt-1">
     <slot name="errorMessage"/>
 </div>
 </template>

--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -84,7 +84,7 @@ const dropdownListItems = computed(() => {
 })
 
 const selectionItem = computed(() => {
-    if(!props.itemValue && props.modelValue) return props.items.filter(item =>{ return item === props.modelValue})[0]
+    if(!props.itemValue && props.modelValue) return props.items.filter(item =>{ return item == props.modelValue})[0]
     if(!props.itemValue && !props.modelValue) return ''
     if(props.modelValue) return props.items.filter(item => {
         if(props.itemValue) return item[props.itemValue] == props.modelValue
@@ -105,8 +105,8 @@ const selectionSlotDisplay = computed(() => {
 })
 
 const liClass= (item:any) => {
-    if(props.itemValue) return item[props.itemValue]===selectionItem.value[props.itemValue]?'bg-blue-50 text-blue-700':''
-    return item === selectionItem.value ? 'bg-blue-50 text-blue-700':''
+    if(props.itemValue) return item[props.itemValue]==selectionItem.value[props.itemValue]?'bg-blue-50 text-blue-700':''
+    return item == selectionItem.value ? 'bg-blue-50 text-blue-700':''
 }
 
 const selectItem = (option: any) => {

--- a/src/components/form/CTextField.story.vue
+++ b/src/components/form/CTextField.story.vue
@@ -216,7 +216,7 @@ const 警告 : {
 | modelValue | string | '' | コンポーネントのv-model値です |
 | label | string | '' | ラベルに設定するテキストを指定します |
 | variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
-| isError | boolean | false | コンポーネントをエラー状態にするかどうか |
+| isError | boolean | false | コンポーネントをエラー状態にする場合は指定します |
 
 ## Slots
 

--- a/src/components/form/CTextField.story.vue
+++ b/src/components/form/CTextField.story.vue
@@ -216,13 +216,13 @@ const 警告 : {
 | modelValue | string | '' | コンポーネントのv-model値です |
 | label | string | '' | ラベルに設定するテキストを指定します |
 | variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
-| isError | boolean | false | コンポーネントをエラー状態にします |
+| isError | boolean | false | コンポーネントをエラー状態にするかどうか |
 
 ## Slots
 
 | Name | Props (if scoped) | Description |
 | --- | --- | --- |
-| errorMessage | errorMessage | エラーの時のメッセージを表示する時に使用します |
+| errorMessage |  | エラーの時のメッセージを表示する時に使用します |
 
 ## Events
 

--- a/src/components/layout/CBox.story.vue
+++ b/src/components/layout/CBox.story.vue
@@ -60,7 +60,7 @@ const data: {
 | Name     | Type                                  | Default  | Description                 |
 | -------- | ------------------------------------- | -------- | --------------------------- |
 | padding  | "none" / "small" / "medium" / "large" | "medium" | padding の指定              |
-| bordered | boolean                               | false    | border を有効にするかどうか |
+| bordered | boolean                               | false    | borderを有効にする場合は指定します |
 
 ## Slots
 

--- a/src/components/layout/CCenter.story.vue
+++ b/src/components/layout/CCenter.story.vue
@@ -84,8 +84,8 @@ const data: {
 | -------- | ------------------------------------- | -------- | --------------------------- |
 | max | string | '100%' | cssのmax-widthの値 |
 | gutters | string | '1rem' | コンテンツの両端の最小限のスペース|
-| andText | boolean | false | テキストも中央揃えにするかどうか(text-align: center) |
-| intrinsic | boolean | false | 子要素をそのコンテンツ幅に基づいて中央揃えにさせるか |
+| andText | boolean | false | テキストも中央揃えにする場合は指定します(text-align: center) |
+| intrinsic | boolean | false | 子要素をそのコンテンツ幅に基づいて中央揃えにする場合は指定します |
 
 ## Slots
 

--- a/src/components/layout/CCover.story.vue
+++ b/src/components/layout/CCover.story.vue
@@ -99,7 +99,7 @@ const data: {
 | centered | string | 'div' | 単純なセレクタとしてCover内に中央揃えされる主要素を指定 |
 | space | string | '1rem' | すべての子要素の間や周囲にできる最小のスペース |
 | minHeight | string | '100vh' | コンポーネントの最小の高さ |
-| noPad | boolean | false | コンテナ要素のpaddingにもスペースを適用するかどうか |
+| noPad | boolean | false | コンテナ要素のpaddingにもスペースを適用する場合は指定します |
 
 ## Slots
 

--- a/src/components/layout/CImposter.story.vue
+++ b/src/components/layout/CImposter.story.vue
@@ -111,9 +111,9 @@ const data: {
 
 | Name     | Type                                  | Default  | Description                 |
 | -------- | ------------------------------------- | -------- | --------------------------- |
-| breakout | boolean | false | 位置指定コンテナから要素がはみ出しても良いか |
+| breakout | boolean | false | 位置指定コンテナから要素がはみ出させる場合は指定します |
 | margin | string | "0px" | (breakoutが適用されていない場合に)要素が配置される位置指定コンテナの内側の縁と要素との間にできる最小の余白 |
-| fixed | boolean | false | 要素をビューポート基準に配置するかどうか |
+| fixed | boolean | false | 要素をビューポート基準に配置する場合は指定します |
 
 ## Slots
 

--- a/src/components/layout/CReel.story.vue
+++ b/src/components/layout/CReel.story.vue
@@ -85,7 +85,7 @@ const data: {
 | itemWidth | string | "auto" | 各項目(子要素)の幅 |
 | space | string | "1rem" | 各項目(子要素)間とReelのmarginのスペース |
 | height | string | "auto" | Reel自体の高さ |
-| noBar | boolean | false | スクロールバーを表示するかどうか |
+| noBar | boolean | false | スクロールバーを表示しない場合は指定します |
 
 ## Slots
 

--- a/src/components/layout/CSidebar.story.vue
+++ b/src/components/layout/CSidebar.story.vue
@@ -125,7 +125,7 @@ const data: {
 | sideWidth | string | "auto" | 垂直方向の配置におけるサイドバーの幅 |
 | contentMin | string | "50%" | cssのパーセンテージの値。水平方向の配置の場合のコンテンツの最小値 |
 | space | string | "1rem" | 二つの要素間のスペースを表すcssのmarginの値 |
-| noStretch | boolean | false | 垂直方向の配置において、要素の本来の(コンテンツに応じた)高さになるようにするか |
+| noStretch | boolean | false | 垂直方向の配置において、要素の本来の(コンテンツに応じた)高さになるようにする場合は指定します |
 
 ## Slots
 

--- a/src/components/layout/CStack.story.vue
+++ b/src/components/layout/CStack.story.vue
@@ -75,7 +75,7 @@ const data: {
 | Name     | Type                                  | Default  | Description                 |
 | -------- | ------------------------------------- | -------- | --------------------------- |
 | space | string | "1rem" | 要素間のスペースを指定するmarginの値 |
-| recursive | boolean | false | スペースが再帰的に(入れ子階層に関係なく)適用されるか |
+| recursive | boolean | false | スペースが再帰的に(入れ子階層に関係なく)適用させたい場合は指定します |
 | splitAfter | number | 0(max10) | Stackを区分けするために後ろにautoマージンを適用する要素の位置 |
 
 ## Slots

--- a/src/components/overlay/CDialog.story.vue
+++ b/src/components/overlay/CDialog.story.vue
@@ -168,7 +168,7 @@ const longData: {
 
 | Name     | Type                         | Default  | Description                          |
 | -------- | ---------------------------- | -------- | ------------------------------------ |
-| modelValue | boolean                      | false    | ダイアログを表示するかどうか         |
+| modelValue | boolean                      | false    | ダイアログを表示する場合は指定します         |
 | size     | "small" / "medium" / "large" | "medium" | ダイアログの横幅のサイズを指定します |
 
 ## Slots


### PR DESCRIPTION
#23

AutocompleteコンポーネントとCSvgIconコンポーネントを作成しました。
(CSvgIconコンポーネントは、svgタグでmaterial design iconなどの表示を行うためのコンポーネントです。)

## CAutocompleteの画面
<img width="938" alt="image" src="https://user-images.githubusercontent.com/101681088/221493251-09fd0a7e-c898-4ab4-8d20-1b9c11b32dc0.png">

## CSvgIconの画面
<img width="948" alt="スクリーンショット 2023-02-27 10 48 13" src="https://user-images.githubusercontent.com/101681088/221456941-c2f14eda-c496-4268-b0f7-8db1dcd125f6.png">

## ブラウザ確認
- Google Chrome
- FireFox
- Edge
- Safari