### PR TITLE
TextFieldでMailAddress, Passwordを扱えるようにする

### DIFF
--- a/src/components/form/CTextField.story.vue
+++ b/src/components/form/CTextField.story.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import {reactive} from "vue";
+import { mdiEye, mdiEyeOff } from "@mdi/js";
 import CTextField from "@/components/form/CTextField.vue";
 import CBox from "@/components/layout/CBox.vue";
 import CStack from "@/components/layout/CStack.vue";
@@ -32,6 +33,28 @@ const underline: {
     入力値: '',
     ラベル: 'underlinedのラベル',
     placeholder: '',
+})
+
+const email : {
+    入力値: string
+    ラベル: string
+    placeholder: string
+} = reactive({
+    入力値: '',
+    ラベル: 'emailのラベル',
+    placeholder: 'email@address.com',
+})
+
+const password : {
+    入力値: string
+    ラベル: string
+    placeholder: string
+    show: boolean
+} = reactive({
+    入力値: 'password',
+    ラベル: 'emailのラベル',
+    placeholder: '',
+    show: false,
 })
 
 const 非活性 : {
@@ -102,8 +125,8 @@ const 警告 : {
             <HstText v-model="outline.ラベル" title="label"/>
             <HstText v-model="outline.placeholder" title="placeholder"/>
         </template>
-
     </Variant>
+
     <Variant title="underlined">
         <c-box padding="medium">
             <c-text-field 
@@ -119,8 +142,33 @@ const 警告 : {
             <HstText v-model="underline.ラベル" title="label"/>
             <HstText v-model="underline.placeholder" title="placeholder"/>
         </template>
-
     </Variant>
+
+    <Variant title="email">
+        <c-box padding="medium">
+            <c-text-field 
+                v-model="email.入力値"
+                :label="email.ラベル"
+                :placeholder="email.placeholder"
+                id="email"
+            />
+        </c-box>
+    </Variant> 
+    
+    <Variant title="password">
+        <c-box padding="medium">
+            <c-text-field 
+                v-model="password.入力値"
+                :label="password.ラベル"
+                :placeholder="password.placeholder"
+                :append-icon="password.show ? mdiEye : mdiEyeOff"
+                :type="password.show?'text':'password'"
+                @click:append="password.show = !password.show"
+                id="password"
+            />
+        </c-box>
+    </Variant>    
+
     <Variant title="非活性">
         <c-box padding="medium">
             <c-stack>
@@ -215,8 +263,11 @@ const 警告 : {
 | --- | --- | --- | --- |
 | modelValue | string | '' | コンポーネントのv-model値です |
 | label | string | '' | ラベルに設定するテキストを指定します |
+| type | 'text'/'email'/'password' | 'text' | inputのtype属性を選択します |
 | variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
 | isError | boolean | false | コンポーネントをエラー状態にする場合は指定します |
+| appendIcon | string | undefined | iconを入力フォームの右に追加する場合は指定します |
+| prependIcon | string | undefined | iconを入力フォームの左に追加する場合は指定します |
 
 ## Slots
 
@@ -229,5 +280,7 @@ const 警告 : {
 | Name | Parameters | Description |
 | --- | --- | --- |
 | update:modelValue | - | コンポーネントのv-modelが変更されたときに発行されるイベントです |
+| click:append | - | 入力フォームの右側に表示されたアイコンをクリックした時に発行されるイベントです |
+| click:prepend | - | 入力フォームの左側に表示されたアイコンをクリックした時に発行されるイベントです |
 
 </docs>

--- a/src/components/form/CTextField.vue
+++ b/src/components/form/CTextField.vue
@@ -1,19 +1,26 @@
 <script setup lang="ts">
 import {computed} from 'vue';
+import CSvgIcon from '@/components/dataDisplay/CSvgIcon.vue';
 
 const props = withDefaults(defineProps<{
     modelValue: string
     label?: string
     variant?: 'filled'|'outlined'|'underlined'
     isError?: boolean
+    type?: 'text'|'email'|'password'
+    appendIcon?: string
+    prependIcon?: string
 }>(), {
     label: '',
     variant: 'filled',
     isError: false,
+    type: 'text'
 })
 
 const emits = defineEmits<{
     (e: 'update:modelValue', value: string): void
+    (e: 'click:append'): void
+    (e: 'click:prepend'): void
 }>()
 
 const inputValue = computed({
@@ -38,21 +45,21 @@ const inputClass = computed(() => {
 
 const labelClass = computed(() => {
     const base = [
-        'absolute text-sm duration-300 transform scale-75 origin-[0] peer-focus:scale-75 whitespace-nowrap overflow-hidden pointer-events-none',
+        'absolute text-sm duration-300 transform origin-[0] peer-focus:scale-75 whitespace-nowrap overflow-hidden pointer-events-none',
     ]
     if(props.isError) base.push('text-[var(--jupiter-danger-text)]')
     if(!props.isError) base.push('text-gray-500 peer-read-only:peer-focus:text-gray-900 peer-focus:text-blue-600')
     if(props.variant === 'filled') base.push(
         '-translate-y-4 top-4 z-10 left-2.5 peer-focus:-translate-y-4',
-        props.modelValue ? 'peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0' : 'scale-100 translate-y-0'
+        props.modelValue ? 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0' : 'scale-100 translate-y-0'
         )
     if(props.variant === 'outlined') base.push(
         '-translate-y-4 top-4 z-10 px-2 peer-focus:px-2 peer-focus:-translate-y-4 left-1 top-4',
-        props.modelValue ? 'peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-0' : 'scale-100 -translate-y-0'
+        props.modelValue ? 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-0' : 'scale-100 -translate-y-0'
         )
     if(props.variant === 'underlined') base.push(
         '-translate-y-5 top-3 z-10 peer-focus:left-0 peer-focus:-translate-y-5',
-        props.modelValue ? 'peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0' : 'scale-100 translate-y-0'
+        props.modelValue ? 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0' : 'scale-100 translate-y-0'
         )
 
     return base
@@ -60,21 +67,25 @@ const labelClass = computed(() => {
 </script>
 
 <template>
-<div class="relative z-0">
-    <input 
-        v-model="inputValue"
-        v-bind="$attrs"
-        type="text" 
-        :class="inputClass" 
-    />
-    <label 
-        :class="labelClass"
-    >
-        {{ label }}
-    </label>
-    <div v-show="isError" class="text-xs text-[var(--jupiter-danger-text)] pt-1">
-        <slot name="errorMessage"/>
+<div class="w-full flex items-center gap-2">
+    <c-svg-icon v-if="prependIcon" @click="$emit('click:prepend')" :icon="prependIcon" size="large" class="cursor-pointer" :class="isError?'text-[var(--jupiter-danger-text)]':'text-gray-600'"/>
+    <div class="relative z-0 w-full">
+        <input 
+            v-model="inputValue"
+            v-bind="$attrs"
+            :type="type" 
+            :class="inputClass" 
+        />
+        <label 
+            :class="labelClass"
+        >
+            {{ label }}
+        </label>
+        <div v-show="isError" class="text-xs text-[var(--jupiter-danger-text)] pt-1">
+            <slot name="errorMessage"/>
+        </div>
     </div>
+    <c-svg-icon v-if="appendIcon" @click="$emit('click:append')" :icon="appendIcon" size="large" class="cursor-pointer" :class="isError?'text-[var(--jupiter-danger-text)]':'text-gray-600'"/>
 </div>
 </template>
 <style module>


### PR DESCRIPTION
#35 

TextField部品に、type属性の、text、email、passwordを扱えるように修正しました。
合わせて、propsとeventを追加しています。

## CTextFieldの画面
<img width="1176" alt="スクリーンショット 2023-03-06 17 40 06" src="https://user-images.githubusercontent.com/101681088/223060551-f3b67947-2a73-43cd-9580-fc9073c47c56.png">
