### PR TITLE
CSelectのラベルがフォーカスが外れている時にも小さくなってしまう

### DIFF
--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -57,9 +57,9 @@ const fieldClass = computed(() => {
 
 const inputClass = computed(() => {
     return [
-        'peer w-full focus:outline-none opacity-100 bg-transparent',
+        'peer w-full focus:outline-none bg-transparent',
         props.label == '' ? 'placeholder:opacity-100': 'placeholder:opacity-0 focus:placeholder:opacity-100',
-        props.modelValue ? 'placeholder:opacity-0' : '',
+        props.modelValue ? 'placeholder:opacity-0' : 'opacity-100',
         props.variant === 'filled' ? 'pt-4 pb-1' : '',
         props.variant === 'outlined' ? 'pt-4 pb-1.5' : '',
         props.variant === 'underlined' ? 'pt-2.5 pb-1' : '',        

--- a/src/components/form/CSelect.story.vue
+++ b/src/components/form/CSelect.story.vue
@@ -123,6 +123,7 @@ const clearable: {
     bloodTypeList: string[]
     label: string
     clearable: boolean
+    variant: 'filled'|'outlined'|'underlined'
 } = reactive({
     modelValue: '',
     bloodTypeList: [
@@ -133,6 +134,7 @@ const clearable: {
     ],
     label: 'ラベル',
     clearable: true,
+    variant: 'filled',
 })
 
 const disabled: {
@@ -221,6 +223,7 @@ const customToggle = () => {
             />
         </c-box>  
         <template #controls>
+            <HstText v-model="data.modelValue" title="modelValue"/>
             <HstJson v-model="data.bloodTypeList" title="items"/>
             <HstText v-model="data.label" title="label"/>
             <HstSelect
@@ -309,10 +312,20 @@ const customToggle = () => {
                 :items="clearable.bloodTypeList"
                 :label="clearable.label"
                 :clearable="clearable.clearable"
+                :variant="clearable.variant"
             />
         </c-box>
         <template #controls>
             <HstCheckbox v-model="clearable.clearable" title="clearable"/>
+            <HstSelect
+            v-model="clearable.variant"
+            title="variant"
+            :options="[
+                {value: 'filled', label: 'filled'},
+                {value: 'outlined', label: 'outlined'},
+                {value: 'underlined', label: 'underlined'},
+            ]"
+            />
         </template>
     </Variant>
     <Variant title="不活性化" auto-props-disabled>

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -48,12 +48,12 @@ const changeableModelValue = computed({
 
 const fieldClass = computed(() => {
     const base = [
-        'group peer flex items-center w-full appearance-none focus:outline-none focus:ring-0 disabled:text-gray-500 opacity-100 border-gray-300',
+        'group peer flex items-center w-full appearance-none focus:outline-none focus:ring-0 disabled:text-gray-500 opacity-100',
         props.label === '' ? 'placeholder:opacity-100': '',
         props.readonly ? 'focus-within:border-gray-900' : 'focus-within:border-blue-600',
         props.isError 
         ? 'border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)] text-[var(--jupiter-danger-text)] placeholder:text-[var(--jupiter-danger-text)] placeholder:opacity-0 focus:placeholder:opacity-50' 
-        : 'placeholder:text-gray-400 placeholder:opacity-0 focus:placeholder:opacity-100',
+        : 'placeholder:text-gray-400 placeholder:opacity-0 focus:placeholder:opacity-100 border-gray-300',
         props.clearable ? 'pr-14' : '',
     ]
     if(props.variant === 'filled') base.push('min-h-[2.7rem] rounded-t-lg rounded-b-none px-2.5 bg-gray-50 border-0 border-b-2')
@@ -76,21 +76,21 @@ const inputClass = computed(() => {
 
 const labelClass = computed(() => {
     const base = [
-        'absolute text-sm duration-300 transform scale-75 origin-[0] peer-focus:scale-75 whitespace-nowrap overflow-hidden pointer-events-none',
+        'absolute text-sm duration-300 transform origin-[0] peer-focus:scale-75 whitespace-nowrap overflow-hidden pointer-events-none',
     ]
     if(props.isError) base.push('text-[var(--jupiter-danger-text)]')
     if(!props.isError) base.push('text-gray-500 peer-focus:text-blue-600')
     if(props.variant === 'filled') base.push(
         '-translate-y-4 top-4 z-10 left-2.5 peer-focus:-translate-y-4',
-        !props.modelValue || !props.modelValue.length ? 'scale-100 translate-y-0' : 'peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0'
+        !props.modelValue || !props.modelValue.length ? 'scale-100 translate-y-0' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0'
         )
     if(props.variant === 'outlined') base.push(
         '-translate-y-4 top-4 z-10 px-2 peer-focus:px-2 peer-focus:-translate-y-4 left-1 top-4',
-        !props.modelValue || !props.modelValue.length ? 'scale-100 -translate-y-0' :'peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-0'
+        !props.modelValue || !props.modelValue.length ? 'scale-100 translate-y-0' :'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-0'
         )
     if(props.variant === 'underlined') base.push(
         '-translate-y-5 top-3 z-10 peer-focus:left-0 peer-focus:-translate-y-5',
-        !props.modelValue || !props.modelValue.length ? 'scale-100 translate-y-0' : 'peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0'
+        !props.modelValue || !props.modelValue.length ? 'scale-100 translate-y-0' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0'
         )
     if(props.readonly) base.push('peer-focus:translate-y-0 peer-focus:scale-100 peer-focus:text-gray-900')
 

--- a/src/components/form/CTextField.vue
+++ b/src/components/form/CTextField.vue
@@ -55,7 +55,7 @@ const labelClass = computed(() => {
         )
     if(props.variant === 'outlined') base.push(
         '-translate-y-4 top-4 z-10 px-2 peer-focus:px-2 peer-focus:-translate-y-4 left-1 top-4',
-        props.modelValue ? 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-0' : 'scale-100 translate-y-0'
+        props.modelValue ? 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0' : 'scale-100 translate-y-0'
         )
     if(props.variant === 'underlined') base.push(
         '-translate-y-5 top-3 z-10 peer-focus:left-0 peer-focus:-translate-y-5',


### PR DESCRIPTION
#56 

Github pageで見た時に、
CSelectコンポーネントのラベルが、フォーカスが外れているときも表示が小さくなってしまうバグを修正しました。

また、以下の点も修正しております。

- CAutocompleteのplaceholderが、項目を選択されているときにも表示されてしまうバグ
- CTextFieldのstyle指定の誤字