### PR TITLE
TextField:エラーメッセージをpropsで渡したい

### DIFF
--- a/src/components/form/CTextField.story.vue
+++ b/src/components/form/CTextField.story.vue
@@ -280,7 +280,7 @@ const error : {
 | type | 'text'/'email'/'password' | 'text' | inputのtype属性を選択します |
 | variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
 | error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
-| errorMessage | string/string[] | '' | エラー状態の場合に表示するメッセージを指定します。(slotsのerrorMessageが使用されている場合、こちらは非表示になります) |
+| errorMessage | string/string[] | '' | コンポーネントをエラー状態にし、表示するメッセージを指定します。(slotsのerrorMessageが使用されている場合、このメッセージは表示されません) |
 | appendIcon | string | undefined | iconを入力フォームの右に追加する場合は指定します |
 | prependIcon | string | undefined | iconを入力フォームの左に追加する場合は指定します |
 
@@ -288,7 +288,7 @@ const error : {
 
 | Name | Props (if scoped) | Description |
 | --- | --- | --- |
-| errorMessage |  | エラーの時のメッセージを表示する時に使用します(propsのerrorMessageがしてされている場合、こちらが優先されます) |
+| errorMessage |  | エラーの時のメッセージを表示する時に使用します(propsのerrorMessageが指定されている場合、こちらが優先されます) |
 
 ## Events
 

--- a/src/components/form/CTextField.story.vue
+++ b/src/components/form/CTextField.story.vue
@@ -79,12 +79,19 @@ const error : {
     underlined入力値: string
     ラベル: string
     placeholder: string
+    error: boolean
+    errorMessage: string|Array<string>
 } = reactive({
     filled入力値: '',
     outlined入力値: '',
     underlined入力値: '',
     ラベル: 'ラベル',
     placeholder: '入力してください',
+    error: true,
+    errorMessage: [
+        '入力が必須です',
+        '最大文字数制限(10文字)を超えています'
+    ],
 })
 
 </script>
@@ -110,7 +117,7 @@ const error : {
         </template>
     </Variant>
 
-    <Variant title="outlined">
+    <Variant title="outlined" auto-props-disabled>
         <c-box padding="medium">
             <c-text-field 
                 v-model="outline.入力値"
@@ -127,7 +134,7 @@ const error : {
         </template>
     </Variant>
 
-    <Variant title="underlined">
+    <Variant title="underlined" auto-props-disabled>
         <c-box padding="medium">
             <c-text-field 
                 v-model="underline.入力値"
@@ -144,7 +151,7 @@ const error : {
         </template>
     </Variant>
 
-    <Variant title="email">
+    <Variant title="email" auto-props-disabled>
         <c-box padding="medium">
             <c-text-field 
                 v-model="email.入力値"
@@ -155,7 +162,7 @@ const error : {
         </c-box>
     </Variant> 
     
-    <Variant title="password">
+    <Variant title="password" auto-props-disabled>
         <c-box padding="medium">
             <c-text-field 
                 v-model="password.入力値"
@@ -169,7 +176,7 @@ const error : {
         </c-box>
     </Variant>    
 
-    <Variant title="非活性">
+    <Variant title="非活性" auto-props-disabled>
         <c-box padding="medium">
             <c-stack>
                 <c-text-field 
@@ -193,7 +200,7 @@ const error : {
         </c-box>
     </Variant>
 
-    <Variant title="読み取り専用">
+    <Variant title="読み取り専用" auto-props-disabled>
         <c-box padding="medium">
             <c-stack>
                 <c-text-field 
@@ -217,18 +224,19 @@ const error : {
         </c-box>
     </Variant>
 
-    <Variant title="警告">
+    <Variant title="警告" auto-props-disabled>
         <c-box padding="medium">
             <c-stack>
                 <c-text-field 
                     v-model="error.filled入力値"
                     :label="error.ラベル"
                     :placeholder="error.placeholder"
-                    error
+                    :error="error.error"
+                    :error-message="error.errorMessage"
                     id="dangerfilled"
                 >
                     <template #errorMessage>
-                        エラーメッセージを表示します
+                        入力してください(slotsが優先されます)
                     </template>
                 </c-text-field>
                 <c-text-field 
@@ -236,7 +244,8 @@ const error : {
                     :label="error.ラベル"
                     :placeholder="error.placeholder"
                     variant="outlined"
-                    error
+                    :error="error.error"
+                    :error-message="error.errorMessage"
                     id="dangeroutlined"
                 />
                 <c-text-field 
@@ -244,11 +253,16 @@ const error : {
                     :label="error.ラベル"
                     :placeholder="error.placeholder"
                     variant="underlined"
-                    error
+                    :error="error.error"
+                    :error-message="error.errorMessage"
                     id="dangerunderlined"
                 />
             </c-stack>
         </c-box>
+        <template #controls>
+            <HstCheckbox v-model="error.error" title="error"/>
+            <HstJson v-model="error.errorMessage" title="errorMessage"/>
+        </template>
     </Variant>
 
 </Story>
@@ -266,6 +280,7 @@ const error : {
 | type | 'text'/'email'/'password' | 'text' | inputのtype属性を選択します |
 | variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
 | error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
+| errorMessage | string|string[] | '' | エラー状態の場合に表示するメッセージを指定します。(slotsのerrorMessageが使用されている場合、こちらは非表示になります) |
 | appendIcon | string | undefined | iconを入力フォームの右に追加する場合は指定します |
 | prependIcon | string | undefined | iconを入力フォームの左に追加する場合は指定します |
 
@@ -273,7 +288,7 @@ const error : {
 
 | Name | Props (if scoped) | Description |
 | --- | --- | --- |
-| errorMessage |  | エラーの時のメッセージを表示する時に使用します |
+| errorMessage |  | エラーの時のメッセージを表示する時に使用します(propsのerrorMessageがしてされている場合、こちらが優先されます) |
 
 ## Events
 

--- a/src/components/form/CTextField.story.vue
+++ b/src/components/form/CTextField.story.vue
@@ -280,7 +280,7 @@ const error : {
 | type | 'text'/'email'/'password' | 'text' | inputのtype属性を選択します |
 | variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
 | error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
-| errorMessage | string|string[] | '' | エラー状態の場合に表示するメッセージを指定します。(slotsのerrorMessageが使用されている場合、こちらは非表示になります) |
+| errorMessage | string/string[] | '' | エラー状態の場合に表示するメッセージを指定します。(slotsのerrorMessageが使用されている場合、こちらは非表示になります) |
 | appendIcon | string | undefined | iconを入力フォームの右に追加する場合は指定します |
 | prependIcon | string | undefined | iconを入力フォームの左に追加する場合は指定します |
 

--- a/src/components/form/CTextField.vue
+++ b/src/components/form/CTextField.vue
@@ -40,11 +40,17 @@ const formatedErrorMessage = computed(() => {
     return props.errorMessage
 })
 
+const isError = computed(() => {
+    if(props.error) return true
+    if(formatedErrorMessage.value.length) return true
+    return false
+})
+
 const inputClass = computed(() => {
     const base = [
         'peer block w-full appearance-none text-gray-900 focus:outline-none focus:ring-0 disabled:text-gray-500 opacity-100',
         props.label === '' ? 'placeholder:opacity-100': '',
-        props.error ? 'border-[var(--jupiter-danger-border)] placeholder:text-[var(--jupiter-danger-text)] placeholder:opacity-0 focus:placeholder:opacity-50' : 'border-gray-300 read-only:text-gray-500 read-only:focus:border-gray-900 focus:border-blue-600 placeholder:text-gray-400 placeholder:opacity-0 focus:placeholder:opacity-100',
+        isError.value ? 'border-[var(--jupiter-danger-border)] placeholder:text-[var(--jupiter-danger-text)] placeholder:opacity-0 focus:placeholder:opacity-50' : 'border-gray-300 read-only:text-gray-500 read-only:focus:border-gray-900 focus:border-blue-600 placeholder:text-gray-400 placeholder:opacity-0 focus:placeholder:opacity-100',
     ]
     if(props.variant === 'filled') base.push('rounded-t-lg rounded-b-none px-2.5 pb-1 pt-4 bg-gray-50 border-0 border-b-2')
     if(props.variant === 'outlined') base.push('px-2.5 pb-1.5 pt-4 bg-transparent rounded-lg border')
@@ -57,8 +63,8 @@ const labelClass = computed(() => {
     const base = [
         'absolute text-sm duration-300 transform origin-[0] peer-focus:scale-75 whitespace-nowrap overflow-hidden pointer-events-none',
     ]
-    if(props.error) base.push('text-[var(--jupiter-danger-text)]')
-    if(!props.error) base.push('text-gray-500 peer-read-only:peer-focus:text-gray-900 peer-focus:text-blue-600')
+    if(isError.value) base.push('text-[var(--jupiter-danger-text)]')
+    if(!isError.value) base.push('text-gray-500 peer-read-only:peer-focus:text-gray-900 peer-focus:text-blue-600')
     if(props.variant === 'filled') base.push(
         '-translate-y-4 top-4 z-10 left-2.5 peer-focus:-translate-y-4',
         props.modelValue ? 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0' : 'scale-100 translate-y-0'
@@ -91,7 +97,7 @@ const labelClass = computed(() => {
         >
             {{ label }}
         </label>
-        <div v-show="error" class="text-xs text-[var(--jupiter-danger-text)] pt-1">
+        <div v-show="isError" class="text-xs text-[var(--jupiter-danger-text)] pt-1">
             <div v-if="!slots.errorMessage">
                 <p v-for="(msg,index) in formatedErrorMessage" :key="index">
                     {{ msg }}

--- a/src/components/form/CTextField.vue
+++ b/src/components/form/CTextField.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
-import {computed} from 'vue';
+import {computed, useSlots} from 'vue';
 import CSvgIcon from '@/components/dataDisplay/CSvgIcon.vue';
+
+const slots = useSlots()
 
 const props = withDefaults(defineProps<{
     modelValue: string
     label?: string
     variant?: 'filled'|'outlined'|'underlined'
     error?: boolean
+    errorMessage?: string|string[]
     type?: 'text'|'email'|'password'
     appendIcon?: string
     prependIcon?: string
@@ -14,6 +17,7 @@ const props = withDefaults(defineProps<{
     label: '',
     variant: 'filled',
     error: false,
+    errorMessage: '',
     type: 'text'
 })
 
@@ -30,11 +34,17 @@ const inputValue = computed({
     }
 })
 
+const formatedErrorMessage = computed(() => {
+    if(!props.errorMessage) return []
+    if(typeof props.errorMessage === 'string') return [props.errorMessage]
+    return props.errorMessage
+})
+
 const inputClass = computed(() => {
     const base = [
-        'peer block w-full appearance-none focus:outline-none focus:ring-0 disabled:text-gray-500 opacity-100',
+        'peer block w-full appearance-none text-gray-900 focus:outline-none focus:ring-0 disabled:text-gray-500 opacity-100',
         props.label === '' ? 'placeholder:opacity-100': '',
-        props.error ? 'border-[var(--jupiter-danger-border)] text-[var(--jupiter-danger-text)] placeholder:text-[var(--jupiter-danger-text)] placeholder:opacity-0 focus:placeholder:opacity-50' : 'border-gray-300 text-gray-900 read-only:text-gray-500 read-only:focus:border-gray-900 focus:border-blue-600 placeholder:text-gray-400 placeholder:opacity-0 focus:placeholder:opacity-100',
+        props.error ? 'border-[var(--jupiter-danger-border)] placeholder:text-[var(--jupiter-danger-text)] placeholder:opacity-0 focus:placeholder:opacity-50' : 'border-gray-300 read-only:text-gray-500 read-only:focus:border-gray-900 focus:border-blue-600 placeholder:text-gray-400 placeholder:opacity-0 focus:placeholder:opacity-100',
     ]
     if(props.variant === 'filled') base.push('rounded-t-lg rounded-b-none px-2.5 pb-1 pt-4 bg-gray-50 border-0 border-b-2')
     if(props.variant === 'outlined') base.push('px-2.5 pb-1.5 pt-4 bg-transparent rounded-lg border')
@@ -82,6 +92,11 @@ const labelClass = computed(() => {
             {{ label }}
         </label>
         <div v-show="error" class="text-xs text-[var(--jupiter-danger-text)] pt-1">
+            <div v-if="!slots.errorMessage">
+                <p v-for="(msg,index) in formatedErrorMessage" :key="index">
+                    {{ msg }}
+                </p>
+            </div>
             <slot name="errorMessage"/>
         </div>
     </div>


### PR DESCRIPTION
#49 

TextFieldコンポーネントがerror状態のときに表示させるメッセージを、
slotsだけでなく、propsで渡して、コンポーネント側でスタイルを指定して表示させるようにしました。

<img width="1051" alt="スクリーンショット 2023-03-20 16 40 39" src="https://user-images.githubusercontent.com/101681088/226276717-53eb0fb4-75c8-4e5f-9cb2-ba705945c8e4.png">
