### PR TITLE
componentが期待しているプロパティはフォールスルーに期待せず、propsとして明示する

### DIFF
--- a/src/components/form/CAutocomplete.story.vue
+++ b/src/components/form/CAutocomplete.story.vue
@@ -353,8 +353,10 @@ const オブジェクト配列の絞り込み = (item:名簿型, searchText:stri
 | label | string | '' | ラベルに設定するテキストを指定します |
 | variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
 | readonly | boolean | false | 読み取り専用にする場合は指定します |
+| disabled | boolean | false | 非活性にする場合は指定します |
 | error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
 | clearable | boolean | false | 入力したテキストをクリアするボタンを追加する場合は指定します |
+| placeholder | string | '' | placeholderのメッセージを指定することができます |
 
 ## Slots
 

--- a/src/components/form/CAutocomplete.story.vue
+++ b/src/components/form/CAutocomplete.story.vue
@@ -341,6 +341,7 @@ const オブジェクト配列の絞り込み = (item:名簿型, searchText:stri
 <docs lang="md">
 # CAutocomplete
 入力補完機能のついたフォームコンポーネントです。
+フォールスルー属性が適用されています。
 
 ## Props
 
@@ -352,6 +353,8 @@ const オブジェクト配列の絞り込み = (item:名簿型, searchText:stri
 | filter | (item: any, searchText: string) => boolean | undefined | 絞り込みを行うための関数を指定します |
 | label | string | '' | ラベルに設定するテキストを指定します |
 | variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
+| id | string | undefined | idを指定します |
+| name | string | undefined | nameを指定します |
 | readonly | boolean | false | 読み取り専用にする場合は指定します |
 | disabled | boolean | false | 非活性にする場合は指定します |
 | error | boolean | false | コンポーネントをエラー状態にする場合は指定します |

--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -13,15 +13,19 @@ const props = withDefaults(defineProps<{
     label?: string
     variant?: 'filled'|'outlined'|'underlined'
     readonly?: boolean
+    disabled?: boolean
     error?: boolean
     clearable?: boolean
+    placeholder?: string
 }>(), {
     itemValue: '',
     label: '',
     variant: 'filled',
     readonly: false,
+    disabled:false,
     error: false,
     clearable: false,
+    placeholder: '',
 })
 
 const emits = defineEmits<{
@@ -156,6 +160,8 @@ watchEffect(() => {
             @keyup.delete="clear"
             type="text" 
             :readonly="readonly"
+            :disabled="disabled"
+            :placeholder="placeholder"
             :class="inputClass" 
             autocomplete="off"
         />

--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -12,6 +12,8 @@ const props = withDefaults(defineProps<{
     filter: (item: any, searchText: string) => boolean
     label?: string
     variant?: 'filled'|'outlined'|'underlined'
+    id?: string
+    name?: string
     readonly?: boolean
     disabled?: boolean
     error?: boolean
@@ -159,6 +161,8 @@ watchEffect(() => {
             @blur="closeDropdownList"
             @keyup.delete="clear"
             type="text" 
+            :id="id"
+            :name="name"
             :readonly="readonly"
             :disabled="disabled"
             :placeholder="placeholder"

--- a/src/components/form/CButton.story.vue
+++ b/src/components/form/CButton.story.vue
@@ -70,9 +70,8 @@ const data: {
 <docs lang="md">
 # CButton
 
-基本的なボタン部品です。下記のProps/Eventsの他に、
-html標準のbutton要素と同様の属性/イベントを扱うことができます。
-refs. https://developer.mozilla.org/ja/docs/Web/HTML/Element/button
+基本的なボタン部品です。
+フォールスルー属性が適用されています。
 
 ## Props
 
@@ -80,6 +79,8 @@ refs. https://developer.mozilla.org/ja/docs/Web/HTML/Element/button
 | --- | --- | --- | --- |
 | color | 'white' / 'black' / 'light' / 'dark' / 'primary' / 'link' / 'success' / 'danger' / 'warning' / 'info' | 'light' | ボタンの色を指定します |
 | outlined | boolean | false | ボタンの見た目をアウトラインボタンにする場合は指定します |
+| id | string | undefined | idを指定します |
+| name | string | undefined | nameを指定します |
 
 ## Slots
 

--- a/src/components/form/CButton.vue
+++ b/src/components/form/CButton.vue
@@ -9,9 +9,11 @@ type ColorType =
 const props = withDefaults(defineProps<{
     color?: ColorType
     outlined?: boolean
+    id?:string
+    name?:string
 }>(), {
     color: 'light',
-    outlined: false,
+    outlined: false,    
 })
 
 const themeColor = computed(() => {
@@ -56,7 +58,7 @@ const buttonClass = computed(() => {
 </script>
 
 <template>
-<button :class="buttonClass">
+<button :id="id" :name="name" :class="buttonClass">
     <slot/>
 </button>
 </template>

--- a/src/components/form/CCheckbox.story.vue
+++ b/src/components/form/CCheckbox.story.vue
@@ -215,6 +215,7 @@ refs. https://developer.mozilla.org/ja/docs/Web/HTML/Element/input/checkbox
 | value | string | '' | チェックされた時に返す値を指定します |
 | indeterminate | boolean | false | チェックボックスを不確定状態にする場合は指定します |
 | readonly | boolean | false | 読み取り専用にする場合は指定します |
+| disabled | boolean | false | 非活性にする場合は指定します |
 
 ## Slots
 

--- a/src/components/form/CCheckbox.story.vue
+++ b/src/components/form/CCheckbox.story.vue
@@ -200,9 +200,8 @@ const error: {
 
 <docs lang="md">
 # CCheckbox
-基本的なチェックボックス部品です。下記のProps/Eventsの他に、
-html標準のbutton要素と同様の属性/イベントを扱うことができます。
-refs. https://developer.mozilla.org/ja/docs/Web/HTML/Element/input/checkbox
+基本的なチェックボックス部品です。
+フォールスルー属性が適用されています。
 
 ## Props
 
@@ -213,6 +212,8 @@ refs. https://developer.mozilla.org/ja/docs/Web/HTML/Element/input/checkbox
 | error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
 | label | string | '' | ラベルに設定するテキストを指定します |
 | value | string | '' | チェックされた時に返す値を指定します |
+| id | string | undefined | idを指定します |
+| name | string | undefined | nameを指定します |
 | indeterminate | boolean | false | チェックボックスを不確定状態にする場合は指定します |
 | readonly | boolean | false | 読み取り専用にする場合は指定します |
 | disabled | boolean | false | 非活性にする場合は指定します |

--- a/src/components/form/CCheckbox.vue
+++ b/src/components/form/CCheckbox.vue
@@ -11,6 +11,7 @@ const props = withDefaults(defineProps<{
     value?: string
     indeterminate?:boolean
     readonly?: boolean
+    disabled?: boolean
 }>(), {
     color: 'black',
     error: false,
@@ -18,6 +19,7 @@ const props = withDefaults(defineProps<{
     value: '',
     indeterminate: false,
     readonly: false,
+    disabled: false
 })
 
 const data: {
@@ -82,6 +84,9 @@ const indeterminateClick = () => {
         v-bind="$attrs"
         @click="indeterminateClick"
         :value="value"
+        :indeterminate="indeterminate"
+        :readonly="readonly"
+        :disabled="disabled"
         type="checkbox" 
         class="absolute top-0 left-0 w-auto h-full opacity-0 cursor-pointer peer"/>
         <div :class="iconClass">

--- a/src/components/form/CCheckbox.vue
+++ b/src/components/form/CCheckbox.vue
@@ -9,6 +9,8 @@ const props = withDefaults(defineProps<{
     error?: boolean
     label?: string
     value?: string
+    id?:string
+    name?:string
     indeterminate?:boolean
     readonly?: boolean
     disabled?: boolean
@@ -84,6 +86,8 @@ const indeterminateClick = () => {
         v-bind="$attrs"
         @click="indeterminateClick"
         :value="value"
+        :id="id"
+        :name="name"
         :indeterminate="indeterminate"
         :readonly="readonly"
         :disabled="disabled"

--- a/src/components/form/CSelect.story.vue
+++ b/src/components/form/CSelect.story.vue
@@ -328,7 +328,7 @@ const customToggle = () => {
             />
         </template>
     </Variant>
-    <Variant title="不活性化" auto-props-disabled>
+    <Variant title="非活性" auto-props-disabled>
         <c-box>
             <c-select
                 v-model="disabled.modelValue"

--- a/src/components/form/CSelect.story.vue
+++ b/src/components/form/CSelect.story.vue
@@ -420,6 +420,7 @@ html標準のbutton要素と同様の属性/イベントを扱うことができ
 | variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
 | multiple | boolean | false | 複数選択を可能にする場合は指定します |
 | readonly | boolean | false | 読み取り専用にする場合は指定します |
+| disabled | boolean | false | 非活性にする場合は指定します |
 | error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
 | clearable | boolean | false | 選択した値をクリアするボタンを追加する場合は指定します |
 

--- a/src/components/form/CSelect.story.vue
+++ b/src/components/form/CSelect.story.vue
@@ -406,8 +406,8 @@ const customToggle = () => {
 
 <docs lang="md">
 # CSelect
-基本的なセレクトボックス部品です。下記のProps/Eventsの他に、
-html標準のbutton要素と同様の属性/イベントを扱うことができます。
+基本的なセレクトボックス部品です。
+フォールスルー属性が適用されています。
 
 ## Props
 
@@ -418,6 +418,8 @@ html標準のbutton要素と同様の属性/イベントを扱うことができ
 | itemValue | string | 'value' | itemsがオブジェクトの配列の場合、識別するためのキーを指定することができます |
 | label | string | '' | ラベルに設定するテキストを指定します |
 | variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
+| id | string | undefined | idを指定します |
+| name | string | undefined | nameを指定します |
 | multiple | boolean | false | 複数選択を可能にする場合は指定します |
 | readonly | boolean | false | 読み取り専用にする場合は指定します |
 | disabled | boolean | false | 非活性にする場合は指定します |

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -94,7 +94,7 @@ const labelClass = computed(() => {
         '-translate-y-5 top-3 z-10 peer-focus:left-0 peer-focus:-translate-y-5',
         !props.modelValue || !props.modelValue.length ? 'scale-100 translate-y-0' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0'
         )
-    if(props.readonly) base.push('peer-focus:translate-y-0 peer-focus:scale-100 peer-focus:text-gray-900')
+    if(props.readonly) base.push('peer-focus:translate-y-0 peer-focus:!scale-100 peer-focus:text-gray-900')
 
     return base
 })

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -15,6 +15,7 @@ const props = withDefaults(defineProps<{
     variant?: 'filled'|'outlined'|'underlined'
     multiple?: boolean
     readonly?: boolean
+    disabled?: boolean
     error?: boolean
     clearable?: boolean
 }>(), {
@@ -23,6 +24,7 @@ const props = withDefaults(defineProps<{
     variant: 'filled',
     multiple: false,
     readonly: false,
+    disabled: false,
     error: false,
     clearable: false,
 })
@@ -208,7 +210,8 @@ const clear = () => {
         v-bind="$attrs"
         @focus="openDropdownList" 
         @blur="closeDropdownList"
-        type="text" 
+        type="text"
+        :disabled="disabled"
         readonly
         :class="inputClass">
         <label 

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -13,6 +13,8 @@ const props = withDefaults(defineProps<{
     itemValue?: string
     label?:string
     variant?: 'filled'|'outlined'|'underlined'
+    id?:string
+    name?:string
     multiple?: boolean
     readonly?: boolean
     disabled?: boolean
@@ -211,6 +213,8 @@ const clear = () => {
         @focus="openDropdownList" 
         @blur="closeDropdownList"
         type="text"
+        :id="id"
+        :name="name"
         :disabled="disabled"
         readonly
         :class="inputClass">

--- a/src/components/form/CTextField.story.vue
+++ b/src/components/form/CTextField.story.vue
@@ -270,6 +270,8 @@ const error : {
 
 <docs lang="md">
 # CTextField
+入力フォームの基本的なコンポーネントです。
+フォールスルー属性が適用されています。
 
 ## Props
 
@@ -279,6 +281,8 @@ const error : {
 | label | string | '' | ラベルに設定するテキストを指定します |
 | type | 'text'/'email'/'password' | 'text' | inputのtype属性を選択します |
 | variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
+| id | string | undefined | idを指定します |
+| name | string | undefined | nameを指定します |
 | error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
 | errorMessage | string/string[] | '' | コンポーネントをエラー状態にし、表示するメッセージを指定します。(slotsのerrorMessageが使用されている場合、このメッセージは表示されません) |
 | appendIcon | string | undefined | iconを入力フォームの右に追加する場合は指定します |

--- a/src/components/form/CTextField.story.vue
+++ b/src/components/form/CTextField.story.vue
@@ -283,6 +283,9 @@ const error : {
 | errorMessage | string/string[] | '' | コンポーネントをエラー状態にし、表示するメッセージを指定します。(slotsのerrorMessageが使用されている場合、このメッセージは表示されません) |
 | appendIcon | string | undefined | iconを入力フォームの右に追加する場合は指定します |
 | prependIcon | string | undefined | iconを入力フォームの左に追加する場合は指定します |
+| readonly | boolean | false | 読み取り専用にする場合は指定します |
+| disabled | boolean | false | 非活性にする場合は指定します |
+| placeholder | string | '' | placeholderのメッセージを指定することができます |
 
 ## Slots
 

--- a/src/components/form/CTextField.vue
+++ b/src/components/form/CTextField.vue
@@ -8,6 +8,8 @@ const props = withDefaults(defineProps<{
     modelValue: string
     label?: string
     variant?: 'filled'|'outlined'|'underlined'
+    id?:string
+    name?:string
     error?: boolean
     errorMessage?: string|string[]
     type?: 'text'|'email'|'password'
@@ -95,6 +97,8 @@ const labelClass = computed(() => {
         <input 
             v-model="inputValue"
             v-bind="$attrs"
+            :id="id"
+            :name="name"
             :type="type" 
             :readonly="readonly"
             :disabled="disabled"

--- a/src/components/form/CTextField.vue
+++ b/src/components/form/CTextField.vue
@@ -13,12 +13,18 @@ const props = withDefaults(defineProps<{
     type?: 'text'|'email'|'password'
     appendIcon?: string
     prependIcon?: string
+    readonly?: boolean
+    disabled?: boolean
+    placeholder?: string
 }>(), {
     label: '',
     variant: 'filled',
     error: false,
     errorMessage: '',
-    type: 'text'
+    type: 'text',
+    readonly: false,
+    disabled: false,
+    placeholder: '',
 })
 
 const emits = defineEmits<{
@@ -90,6 +96,9 @@ const labelClass = computed(() => {
             v-model="inputValue"
             v-bind="$attrs"
             :type="type" 
+            :readonly="readonly"
+            :disabled="disabled"
+            :placeholder="placeholder"
             :class="inputClass" 
         />
         <label 

--- a/src/components/form/CTextarea.story.vue
+++ b/src/components/form/CTextarea.story.vue
@@ -174,7 +174,7 @@ const error: {
             <HstText v-model="icons.rows" title="rows"/>
         </template>
     </Variant>
-    <Variant title="不活性化" auto-props-disabled>
+    <Variant title="非活性" auto-props-disabled>
         <c-textarea
         v-model="disabled.modelValue"
         :label="disabled.label"

--- a/src/components/form/CTextarea.story.vue
+++ b/src/components/form/CTextarea.story.vue
@@ -263,6 +263,9 @@ refs. https://developer.mozilla.org/ja/docs/Web/HTML/Element/textarea
 | error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
 | clearable | boolean | false | 入力したテキストをクリアするボタンを追加する場合は指定します |
 | readonly | boolean | false | 読み取り専用にする場合は指定します |
+| disabled | boolean | false | 非活性にする場合は指定します |
+| placeholder | string | '' | placeholderのメッセージを指定することができます |
+| rows | string/number | 2 | コントロールで見ることが可能なテキストの行数を指定できます |
 
 ## Slots
 

--- a/src/components/form/CTextarea.story.vue
+++ b/src/components/form/CTextarea.story.vue
@@ -245,9 +245,8 @@ const error: {
 <docs lang="md">
 # CTextarea
 
-基本的なテキストエリア部品です。複数行の入力が可能です。下記のPropsの他に、
-html標準のtextarea要素と同様の属性を扱うことができます。
-refs. https://developer.mozilla.org/ja/docs/Web/HTML/Element/textarea
+基本的なテキストエリア部品です。複数行の入力が可能です。
+フォールスルー属性が適用されています。
 
 ## Props
 
@@ -256,6 +255,8 @@ refs. https://developer.mozilla.org/ja/docs/Web/HTML/Element/textarea
 | modelValue | any | undefined | コンポーネントのv-model値です |
 | label | string | '' | ラベルに設定するテキストを指定します |
 | variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
+| id | string | undefined | idを指定します |
+| name | string | undefined | nameを指定します |
 | prependIcon | string | undefined | 入力フォームの左外側に表示させるiconを指定します |
 | appendIcon | string | undefined | 入力フォームの右外側に表示させるiconを指定します |
 | prependInnerIcon | string | undefined | 入力フォームの左内側に表示させるiconを指定します |

--- a/src/components/form/CTextarea.vue
+++ b/src/components/form/CTextarea.vue
@@ -16,12 +16,18 @@ const props = withDefaults(defineProps<{
     error?: boolean
     clearable?: boolean
     readonly?: boolean
+    disabled?: boolean
+    placeholder?: string
+    rows?: string|number
 }>(), {
     label: '',
     variant: 'filled',
     error: false,
     clearable: false,
     readonly: false,
+    disabled: false, 
+    placeholder: '',
+    rows: 2,
 })
 
 const emits = defineEmits<{
@@ -117,6 +123,9 @@ const clear = () => {
             v-model="textareaValue"
             v-bind="$attrs"
             :readonly="readonly"
+            :disabled="disabled"
+            :placeholder="placeholder"
+            :rows="rows"
             :class="textareaClass"/>
             <label :class="labelClass">
                 {{ label }}

--- a/src/components/form/CTextarea.vue
+++ b/src/components/form/CTextarea.vue
@@ -9,6 +9,8 @@ const props = withDefaults(defineProps<{
     modelValue: any
     label?: string
     variant?: 'filled'|'outlined'|'underlined'
+    id?:string
+    name?:string
     prependIcon?: string
     appendIcon?: string
     prependInnerIcon?: string
@@ -122,6 +124,8 @@ const clear = () => {
             <textarea
             v-model="textareaValue"
             v-bind="$attrs"
+            :id="id"
+            :name="name"
             :readonly="readonly"
             :disabled="disabled"
             :placeholder="placeholder"


### PR DESCRIPTION
#65 

フォールスルーに期待していたプロパティを、propsに明示するように、修正しました。
また、それに伴い、ドキュメントの変更等も行いました。

(見た目の変更はありません)