### PR TITLE
TextFiled:エラーメッセージを出すとappend-iconの上下位置がズレる

### DIFF
--- a/src/components/form/CTextField.vue
+++ b/src/components/form/CTextField.vue
@@ -91,9 +91,11 @@ const labelClass = computed(() => {
 </script>
 
 <template>
-<div class="w-full flex items-center gap-2">
-    <c-svg-icon v-if="prependIcon" @click="$emit('click:prepend')" :icon="prependIcon" size="large" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-600'"/>
-    <div class="relative z-0 w-full">
+<div class="w-full grid grid-cols-[auto_1fr_auto] gap-2">
+    <div class="col-start-1 self-center">
+        <c-svg-icon v-if="prependIcon" @click="$emit('click:prepend')" :icon="prependIcon" size="large" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-600'"/>
+    </div>
+    <div class="relative z-0 w-full col-start-2">
         <input 
             v-model="inputValue"
             v-bind="$attrs"
@@ -110,16 +112,18 @@ const labelClass = computed(() => {
         >
             {{ label }}
         </label>
-        <div v-show="isError" class="text-xs text-[var(--jupiter-danger-text)] pt-1">
-            <div v-if="!slots.errorMessage">
-                <p v-for="(msg,index) in formatedErrorMessage" :key="index">
-                    {{ msg }}
-                </p>
-            </div>
-            <slot name="errorMessage"/>
-        </div>
     </div>
-    <c-svg-icon v-if="appendIcon" @click="$emit('click:append')" :icon="appendIcon" size="large" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-600'"/>
+    <div class="col-start-3 self-center">
+        <c-svg-icon v-if="appendIcon" @click="$emit('click:append')" :icon="appendIcon" size="large" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-600'"/>
+    </div>
+    <div v-show="isError" class="text-xs text-[var(--jupiter-danger-text)] pt-1 col-start-2">
+        <div v-if="!slots.errorMessage">
+            <p v-for="(msg,index) in formatedErrorMessage" :key="index">
+                {{ msg }}
+            </p>
+        </div>
+        <slot name="errorMessage"/>
+    </div>
 </div>
 </template>
 <style module>

--- a/src/components/form/CTextarea.vue
+++ b/src/components/form/CTextarea.vue
@@ -49,8 +49,7 @@ const textareaValue = computed({
 
 const fieldClass = computed(() => {
     const base = [
-        'group peer flex items-center w-full appearance-none focus:outline-none focus:ring-0 disabled:text-gray-500 opacity-100',
-        // props.clearable ? 'pr-6' : '',
+        'group peer col-start-2 flex items-center w-full appearance-none focus:outline-none focus:ring-0 disabled:text-gray-500 opacity-100',
     ]
     if(props.error) base.push('border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)] placeholder:text-[var(--jupiter-danger-text)] placeholder:opacity-0 focus:placeholder:opacity-50' )
     if(!props.error) {
@@ -112,8 +111,8 @@ const clear = () => {
 </script>
 
 <template>
-<div class="flex items-center">
-    <div v-show="prependIcon" class="px-2 text-lg">
+<div class="grid grid-cols-[auto_1fr_auto] gap-2">
+    <div v-show="prependIcon" class="text-lg col-start-1 self-center">
         <c-svg-icon :icon="prependIcon" @click="$emit('click:prepend')" size="medium" class="text-gray-500 cursor-pointer" />
     </div>
     <div :class="fieldClass">
@@ -142,13 +141,12 @@ const clear = () => {
             <c-svg-icon :icon="appendInnerIcon" @click="$emit('click:appendInner')" size="medium" class="text-gray-500 cursor-pointer" />
         </div>
     </div>
-    <div v-show="appendIcon" class="px-2 text-lg">
+    <div v-show="appendIcon" class="text-lg col-start-3 self-center">
         <c-svg-icon :icon="appendIcon" @click="$emit('click:append')" size="medium" class="text-gray-500 cursor-pointer" />
     </div>
-</div>
-
-<div v-show="error && slots.errorMessage" class="text-xs text-[var(--jupiter-danger-text)] pt-1">
-    <slot name="errorMessage"/>
+    <div v-show="error && slots.errorMessage" class="text-xs text-[var(--jupiter-danger-text)] pt-1 col-start-2">
+        <slot name="errorMessage"/>
+    </div>
 </div>
 </template>
 <style module>


### PR DESCRIPTION
#48 

TextField部品で、iconがある時、エラーメッセージを表示させると、フォームとエラーメッセージを合わせた高さの中央にiconが表示されてしまうので、
フォームのみの高さに合わせてiconを表示させるように、(エラーメッセージの有無に関わらず、iconの位置が変わらないように)
修正を行いました。

<img width="400" alt="スクリーンショット 2023-03-24 10 07 43" src="https://user-images.githubusercontent.com/101681088/227398547-153343d5-2b82-4a2f-b290-f25444d28848.png">
<img width="405" alt="スクリーンショット 2023-03-24 10 07 48" src="https://user-images.githubusercontent.com/101681088/227398551-02135908-54f8-4625-9f8f-b54c0787ae03.png">

## 各ブラウザ確認済み

- Google Chrome
- FireFox
- Edge
- Safari
- Android Emulator
- iPhone Simulator