### PR TITLE
フォーム部品: エラーメッセージをpropsで渡すようにし、error-message slotは廃止する

### DIFF
--- a/src/components/form/CAutocomplete.story.vue
+++ b/src/components/form/CAutocomplete.story.vue
@@ -75,15 +75,6 @@ const clearable: {
     スタイル: 'filled'
 })
 
-const error: {
-    選択された値: string
-    error: boolean
-    スタイル: 'filled'|'outlined'|'underlined'
-} = reactive({
-    選択された値: '1',
-    error: true,
-    スタイル: 'filled'
-})
 
 const disabled: {
     選択された値: string
@@ -105,10 +96,29 @@ const readonly: {
     スタイル: 'filled'
 })
 
+const error: {
+    選択された値: string
+    error: boolean
+    スタイル: 'filled'|'outlined'|'underlined'
+    errorMessage: string|string[]|undefined
+    maxErrors: string|undefined
+} = reactive({
+    選択された値: '1',
+    error: true,
+    スタイル: 'filled',
+    errorMessage: [
+        '入力が必須です',
+        '最大文字数制限(10文字)を超えています',
+        '半角英数字を入力してください'
+    ],
+    maxErrors: undefined,
+})
+
 const 文字列配列の絞り込み = (item:string, searchText:string) => {
     const keyword = searchText.toUpperCase()
     return item.toUpperCase().indexOf(keyword) > -1
 }
+
 const オブジェクト配列の絞り込み = (item:名簿型, searchText:string) => {
     const keyword = searchText.toUpperCase()
     if(item.姓.toUpperCase().indexOf(keyword) > -1) return true
@@ -121,7 +131,7 @@ const オブジェクト配列の絞り込み = (item:名簿型, searchText:stri
     title="Form / CAutocomplete"
     :layout="{ type: 'grid', width: 500 }"
 >
-<Variant title="文字列の配列の場合" auto-props-disabled>
+    <Variant title="文字列の配列の場合" auto-props-disabled>
         <c-box padding="large">
             <c-autocomplete
             v-model="string.入力値"
@@ -131,8 +141,7 @@ const オブジェクト配列の絞り込み = (item:名簿型, searchText:stri
             :placeholder="string.placeholder"
             :variant="string.スタイル"
             id="string"
-            >
-            </c-autocomplete>    
+            />
         </c-box>
         <template #controls>
             <HstText v-model="string.入力値" title="modelValue"/>
@@ -301,12 +310,15 @@ const オブジェクト配列の絞り込み = (item:名簿型, searchText:stri
         <c-box padding="large">
             <c-autocomplete
             v-model="error.選択された値"
+            label="ラベル"
             :items="object.名簿"
             item-value="id"
             :filter="オブジェクト配列の絞り込み"
             :variant="error.スタイル"
             placeholder="入力"
             :error="error.error"
+            :error-message="error.errorMessage"
+            :max-errors="error.maxErrors"
             >
                 <template v-slot:selection="{item}">
                     {{ item.姓 }} {{ item.名 }}
@@ -314,16 +326,12 @@ const オブジェクト配列の絞り込み = (item:名簿型, searchText:stri
                 <template v-slot:item="{item}">
                     {{ item.姓 }} {{ item.名 }}
                 </template>
-                <template v-slot:errorMessage>
-                    名前を入力してください
-                </template>
             </c-autocomplete>
         </c-box>
         <template #controls>
-            <HstCheckbox
-                v-model="error.error"
-                title="error"
-            />
+            <HstCheckbox v-model="error.error" title="error"/>
+            <HstJson v-model="error.errorMessage" title="errorMessage"/>
+            <HstText v-model="error.maxErrors" title="maxErrors"/>
             <HstSelect
             v-model="error.スタイル"
             title="variant"
@@ -347,28 +355,29 @@ const オブジェクト配列の絞り込み = (item:名簿型, searchText:stri
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| modelValue | any | null | コンポーネントのv-model値です |
-| items | any[] | [] | オブジェクトの配列、または文字列の配列を指定できます。オブジェクトの配列の場合、itemValueを使用することで、キーを変更できます。 |
-| itemValue | string | '' | itemsがオブジェクトの配列の場合、識別するためのキーを指定することができます |
-| filter | (item: any, searchText: string) => boolean | undefined | 絞り込みを行うための関数を指定します |
-| label | string | '' | ラベルに設定するテキストを指定します |
-| variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
-| id | string | undefined | idを指定します |
-| name | string | undefined | nameを指定します |
-| readonly | boolean | false | 読み取り専用にする場合は指定します |
+| clearable | boolean | false | 入力したテキストをクリアするボタンを追加する場合は指定します |
 | disabled | boolean | false | 非活性にする場合は指定します |
 | error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
-| clearable | boolean | false | 入力したテキストをクリアするボタンを追加する場合は指定します |
+| errorMessage | string/string[] | '' | コンポーネントをエラー状態にし、表示するメッセージを指定します|
+| filter | (item: any, searchText: string) => boolean | undefined | 絞り込みを行うための関数を指定します |
+| id | string | undefined | idを指定します |
+| items | any[] | [] | オブジェクトの配列、または文字列の配列を指定できます。オブジェクトの配列の場合、itemValueを使用することで、キーを変更できます。 |
+| itemValue | string | '' | itemsがオブジェクトの配列の場合、識別するためのキーを指定することができます |
+| label | string | '' | ラベルに設定するテキストを指定します |
+| maxErrors | string/number | undefined | 表示するエラーメッセージの数を制限します |
+| modelValue | any | null | コンポーネントのv-model値です |
+| name | string | undefined | nameを指定します |
 | placeholder | string | '' | placeholderのメッセージを指定することができます |
+| readonly | boolean | false | 読み取り専用にする場合は指定します |
+| variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
 
 ## Slots
 
 | Name | Props (if scoped) | Description |
 | --- | --- | --- |
-| selection | item | 選択された値の表示方法をカスタムできます |
-| item | item/index | ドロップダウンリストの各項目の表示方法をカスタムできます |
 | empty |  | ドロップダウンリストに一件も表示されない時に使用します |
-| errorMessage |  | エラーの時のメッセージを表示する時に使用します |
+| item | item/index | ドロップダウンリストの各項目の表示方法をカスタムできます |
+| selection | item | 選択された値の表示方法をカスタムできます |
 
 ## Events
 

--- a/src/components/form/CCheckbox.story.vue
+++ b/src/components/form/CCheckbox.story.vue
@@ -63,9 +63,17 @@ const readonly: {
 const error: {
     選択値: boolean
     error: boolean
+    errorMessage: string|string[]|undefined
+    maxErrors: string|undefined
 } = reactive({
     選択値: false,
     error: true,
+    errorMessage: [
+        '選択が必須です',
+        '選択が必須です2',
+        '選択が必須です3'
+    ],
+    maxErrors: undefined,
 })
 </script>
 
@@ -185,13 +193,13 @@ const error: {
             v-model="error.選択値"
             label="error"
             :error="error.error"
-        >
-            <template v-slot:errorMessage>
-                選択してください
-            </template>
-        </c-checkbox>
+            :error-message="error.errorMessage"
+            :max-errors="error.maxErrors"
+        />
         <template #controls>
             <HstCheckbox v-model="error.error" title="error"/>
+            <HstJson v-model="error.errorMessage" title="errorMessage"/>
+            <HstText v-model="error.maxErrors" title="maxErrors"/>
         </template>
     </Variant>
 
@@ -207,22 +215,24 @@ const error: {
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| modelValue | any | undefined | コンポーネントのv-model値です |
 | color | 'white' / 'black' / 'light' / 'dark' / 'primary' / 'link' / 'success' / 'danger' / 'warning' / 'info' | 'black' |  |
-| error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
-| label | string | '' | ラベルに設定するテキストを指定します |
-| value | string | '' | チェックされた時に返す値を指定します |
-| id | string | undefined | idを指定します |
-| name | string | undefined | nameを指定します |
-| indeterminate | boolean | false | チェックボックスを不確定状態にする場合は指定します |
-| readonly | boolean | false | 読み取り専用にする場合は指定します |
 | disabled | boolean | false | 非活性にする場合は指定します |
+| error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
+| errorMessage | string/string[] | '' | コンポーネントをエラー状態にし、表示するメッセージを指定します|| maxErrors | string/number | undefined | 表示するエラーメッセージの数を制限します |
+| id | string | undefined | idを指定します |
+| indeterminate | boolean | false | チェックボックスを不確定状態にする場合は指定します |
+| label | string | '' | ラベルに設定するテキストを指定します |
+| maxErrors | string/number | undefined | 表示するエラーメッセージの数を制限します |
+| modelValue | any | undefined | コンポーネントのv-model値です |
+| name | string | undefined | nameを指定します |
+| readonly | boolean | false | 読み取り専用にする場合は指定します |
+| value | string | '' | チェックされた時に返す値を指定します |
 
 ## Slots
 
 | Name | Props (if scoped) | Description |
 | --- | --- | --- |
-| errorMessage |  | エラーの時のメッセージを表示する時に使用します |
+| - | - | このコンポーネント独自のSlotはありません |
 
 ## Events
 

--- a/src/components/form/CCheckbox.vue
+++ b/src/components/form/CCheckbox.vue
@@ -7,6 +7,8 @@ const props = withDefaults(defineProps<{
     modelValue: any
     color?: 'white' | 'black' | 'light' | 'dark' | 'primary' | 'link' | 'success' | 'danger' | 'warning' | 'info'
     error?: boolean
+    errorMessage?: string|string[]
+    maxErrors?: string|number
     label?: string
     value?: string
     id?:string
@@ -17,6 +19,7 @@ const props = withDefaults(defineProps<{
 }>(), {
     color: 'black',
     error: false,
+    errorMessage: '',
     label: '',
     value: '',
     indeterminate: false,
@@ -48,6 +51,21 @@ const iconDisplayStatus = computed(() => {
     return checkboxValue.value.includes(props.value) ? 'marked' : 'blank'
 })
 
+const formatedErrorMessage = computed(() => {
+    const max = Number(props.maxErrors)
+    if(!props.errorMessage) return []
+    if(typeof props.errorMessage === 'string') return new Array(props.errorMessage)
+    if(!isNaN(max)) return props.errorMessage.filter((x, index) => index < max )
+    if(isNaN(max)) return props.errorMessage
+    return props.errorMessage
+})
+
+const isError = computed(() => {
+    if(props.error) return true
+    if(formatedErrorMessage.value.length) return true
+    return false
+})
+
 const iconColor = computed(() => {
     if(props.color === 'white') return 'text-[var(--jupiter-white)]'
     if(props.color === 'black') return 'text-[var(--jupiter-black)]'
@@ -65,10 +83,10 @@ const iconColor = computed(() => {
 const iconClass = computed(() => {
     return [
         'group w-10 h-10 rounded-full flex justify-center items-center',
-        'peer-disabled:text-gray-400 peer-hover:bg-gray-50 peer-hover:peer-disabled:bg-transparent',
+        'peer-disabled:text-gray-400 peer-hover:bg-gray-50 peer-focus:bg-gray-50 peer-hover:peer-disabled:bg-transparent',
         iconDisplayStatus.value === 'blank' ? 'text-[var(--jupiter-black)]' : iconColor.value,
         props.readonly ? 'peer-read-only:text-gray-500' : '',
-        props.error ? 'text-[var(--jupiter-danger-text)]' : '',
+        isError.value ? 'text-[var(--jupiter-danger-text)]' : '',
     ]
 })
 
@@ -77,8 +95,8 @@ const labelClass = computed(() => {
         'text-base peer-disabled:text-gray-400',
     ]
     if(props.readonly) base.push('text-gray-500')
-    if(props.error) base.push('text-[var(--jupiter-danger-text)]')
-    if(!props.readonly && !props.error) base.push('text-[var(--jupiter-black)]')
+    if(isError.value) base.push('text-[var(--jupiter-danger-text)]')
+    if(!props.readonly && !isError.value) base.push('text-[var(--jupiter-black)]')
 
     return base
 })
@@ -114,7 +132,9 @@ const indeterminateClick = () => {
         </div>
     </label>
 </div>
-<div v-show="error" class="text-xs text-[var(--jupiter-danger-text)] pt-1 pl-2">
-    <slot name="errorMessage"/>
+<div v-show="isError" class="text-xs text-[var(--jupiter-danger-text)] pt-1 pl-2">
+    <p v-for="(msg,index) in formatedErrorMessage" :key="index">
+        {{ msg }}
+    </p>
 </div>
 </template>

--- a/src/components/form/CSelect.story.vue
+++ b/src/components/form/CSelect.story.vue
@@ -182,6 +182,8 @@ const error: {
     bloodTypeList: string[]
     label: string
     error: boolean
+    errorMessage: string|string[]|undefined
+    maxErrors: string|undefined
     variant: 'filled'|'outlined'|'underlined'
 } = reactive({
     modelValue: '',
@@ -193,7 +195,13 @@ const error: {
     ],
     label: 'ラベル',
     error: true,
-    variant: 'filled'
+    variant: 'filled',
+    errorMessage: [
+        '入力が必須です',
+        '最大文字数制限(10文字)を超えています',
+        '半角英数字を入力してください'
+    ],
+    maxErrors: undefined,
 })
 
 const isAllChecked = computed({
@@ -386,14 +394,15 @@ const customToggle = () => {
                 :label="error.label"
                 :variant="error.variant"
                 :error="error.error"
-            >
-            <template v-slot:errorMessage>
-                入力してください
-            </template>
-            </c-select>
+                :error-message="error.errorMessage"
+                :max-errors="error.maxErrors"
+                clearable
+            />
         </c-box>
         <template #controls>
             <HstCheckbox v-model="error.error" title="error"/>
+            <HstJson v-model="error.errorMessage" title="errorMessage"/>
+            <HstText v-model="error.maxErrors" title="maxErrors"/>
             <HstSelect
             v-model="data.variant"
             title="variant"
@@ -417,19 +426,21 @@ const customToggle = () => {
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| modelValue | any | null | コンポーネントのv-model値です |
+| clearable | boolean | false | 選択した値をクリアするボタンを追加する場合は指定します |
+| disabled | boolean | false | 非活性にする場合は指定します |
+| error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
+| errorMessage | string/string[] | '' | コンポーネントをエラー状態にし、表示するメッセージを指定します|
+| id | string | undefined | idを指定します |
 | items | any[] | [] | オブジェクトの配列、または文字列の配列を指定できます。オブジェクトの配列の場合、itemValueを使用することで、キーを変更できます。 |
 | itemValue | string | 'value' | itemsがオブジェクトの配列の場合、識別するためのキーを指定することができます |
 | label | string | '' | ラベルに設定するテキストを指定します |
-| variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
-| id | string | undefined | idを指定します |
+| maxErrors | string/number | undefined | 表示するエラーメッセージの数を制限します |
+| modelValue | any | null | コンポーネントのv-model値です |
+| multiple | boolean | false | 複数選択を可能にする場合は指定します |
 | name | string | undefined | nameを指定します |
 | placeholder | string | undefined | placeholderに表示するメッセージを指定します |
-| multiple | boolean | false | 複数選択を可能にする場合は指定します |
 | readonly | boolean | false | 読み取り専用にする場合は指定します |
-| disabled | boolean | false | 非活性にする場合は指定します |
-| error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
-| clearable | boolean | false | 選択した値をクリアするボタンを追加する場合は指定します |
+| variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
 
 ## Slots
 
@@ -439,7 +450,6 @@ const customToggle = () => {
 | prependItem |  | ドロップダウンリストの先頭に追加する表示項目を指定します |
 | item | item/index| ドロップダウンリストの各項目の表示方法をカスタムできます |
 | empty |  | ドロップダウンリストに一件も表示されない時に使用します |
-| errorMessage |  | エラーの時のメッセージを表示する時に使用します |
 
 ## Events
 

--- a/src/components/form/CSelect.story.vue
+++ b/src/components/form/CSelect.story.vue
@@ -446,10 +446,10 @@ const customToggle = () => {
 
 | Name | Props (if scoped) | Description |
 | --- | --- | --- |
-| selection | item / index| 選択された値の表示方法をカスタムできます |
-| prependItem |  | ドロップダウンリストの先頭に追加する表示項目を指定します |
-| item | item/index| ドロップダウンリストの各項目の表示方法をカスタムできます |
 | empty |  | ドロップダウンリストに一件も表示されない時に使用します |
+| item | item/index| ドロップダウンリストの各項目の表示方法をカスタムできます |
+| prependItem |  | ドロップダウンリストの先頭に追加する表示項目を指定します |
+| selection | item / index| 選択された値の表示方法をカスタムできます |
 
 ## Events
 

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -31,6 +31,7 @@ const props = withDefaults(defineProps<{
     readonly: false,
     disabled: false,
     error: false,
+    errorMessage: '',
     clearable: false,
 })
 

--- a/src/components/form/CTextField.story.vue
+++ b/src/components/form/CTextField.story.vue
@@ -3,7 +3,6 @@ import {reactive} from "vue";
 import { mdiEye, mdiEyeOff } from "@mdi/js";
 import CTextField from "@/components/form/CTextField.vue";
 import CBox from "@/components/layout/CBox.vue";
-import CStack from "@/components/layout/CStack.vue";
 
 const filled: {
     入力値: string
@@ -60,17 +59,21 @@ const password : {
 const disabled : {
     入力値: string
     ラベル: string
+    variant: 'filled'|'outlined'|'underlined'
 } = reactive({
     入力値: '吾輩は猫である',
     ラベル: '夏目漱石',
+    variant: 'filled',
 })
 
 const readonly : {
     入力値: string
     ラベル: string
+    variant: 'filled'|'outlined'|'underlined'
 } = reactive({
     入力値: 'セロ弾きのゴーシュ',
     ラベル: '宮沢賢治',
+    variant: 'filled',
 })
 
 const error : {
@@ -79,19 +82,24 @@ const error : {
     underlined入力値: string
     ラベル: string
     placeholder: string
+    variant: 'filled'|'outlined'|'underlined'
     error: boolean
     errorMessage: string|Array<string>
+    maxErrors: string|undefined
 } = reactive({
     filled入力値: '',
     outlined入力値: '',
     underlined入力値: '',
     ラベル: 'ラベル',
     placeholder: '入力してください',
+    variant: 'filled',
     error: true,
     errorMessage: [
         '入力が必須です',
-        '最大文字数制限(10文字)を超えています'
+        '最大文字数制限(10文字)を超えています',
+        '半角英数字を入力してください'
     ],
+    maxErrors: undefined,
 })
 
 </script>
@@ -178,90 +186,74 @@ const error : {
 
     <Variant title="非活性" auto-props-disabled>
         <c-box padding="medium">
-            <c-stack>
-                <c-text-field 
-                    v-model="disabled.入力値"
-                    :label="disabled.ラベル"
-                    disabled
-                />
-                <c-text-field 
-                    v-model="disabled.入力値"
-                    :label="disabled.ラベル"
-                    variant="outlined"
-                    disabled
-                />
-                <c-text-field 
-                    v-model="disabled.入力値"
-                    :label="disabled.ラベル"
-                    variant="underlined"
-                    disabled
-                />
-            </c-stack>
+            <c-text-field 
+                v-model="disabled.入力値"
+                :label="disabled.ラベル"
+                :variant="disabled.variant"
+                disabled
+            />
         </c-box>
+        <template #controls>
+            <HstSelect
+            v-model="disabled.variant"
+            title="variant"
+            :options="[
+                {value: 'filled', label: 'filled'},
+                {value: 'outlined', label: 'outlined'},
+                {value: 'underlined', label: 'underlined'},
+            ]"
+            />
+        </template>
     </Variant>
 
     <Variant title="読み取り専用" auto-props-disabled>
         <c-box padding="medium">
-            <c-stack>
-                <c-text-field 
-                    v-model="readonly.入力値"
-                    :label="readonly.ラベル"
-                    readonly
-                />
-                <c-text-field 
-                    v-model="readonly.入力値"
-                    :label="readonly.ラベル"
-                    variant="outlined"
-                    readonly
-                />
-                <c-text-field 
-                    v-model="readonly.入力値"
-                    :label="readonly.ラベル"
-                    variant="underlined"
-                    readonly
-                />
-            </c-stack>
+            <c-text-field 
+                v-model="readonly.入力値"
+                :label="readonly.ラベル"
+                :variant="readonly.variant"
+                readonly
+            />
         </c-box>
+        <template #controls>
+            <HstSelect
+            v-model="readonly.variant"
+            title="variant"
+            :options="[
+                {value: 'filled', label: 'filled'},
+                {value: 'outlined', label: 'outlined'},
+                {value: 'underlined', label: 'underlined'},
+            ]"
+            />
+        </template>
     </Variant>
 
     <Variant title="警告" auto-props-disabled>
         <c-box padding="medium">
-            <c-stack>
-                <c-text-field 
-                    v-model="error.filled入力値"
-                    :label="error.ラベル"
-                    :placeholder="error.placeholder"
-                    :error="error.error"
-                    :error-message="error.errorMessage"
-                    id="dangerfilled"
-                >
-                    <template #errorMessage>
-                        入力してください(slotsが優先されます)
-                    </template>
-                </c-text-field>
-                <c-text-field 
-                    v-model="error.outlined入力値"
-                    :label="error.ラベル"
-                    :placeholder="error.placeholder"
-                    variant="outlined"
-                    :error="error.error"
-                    :error-message="error.errorMessage"
-                    id="dangeroutlined"
-                />
-                <c-text-field 
-                    v-model="error.underlined入力値"
-                    :label="error.ラベル"
-                    :placeholder="error.placeholder"
-                    variant="underlined"
-                    :error="error.error"
-                    :error-message="error.errorMessage"
-                    id="dangerunderlined"
-                />
-            </c-stack>
+            <c-text-field 
+                v-model="error.filled入力値"
+                :label="error.ラベル"
+                :placeholder="error.placeholder"
+                :variant="error.variant"
+                :error="error.error"
+                :error-message="error.errorMessage"
+                :max-errors="error.maxErrors"
+                id="error"
+            />
         </c-box>
         <template #controls>
             <HstCheckbox v-model="error.error" title="error"/>
             <HstJson v-model="error.errorMessage" title="errorMessage"/>
+            <HstText v-model="error.maxErrors" title="maxErrors"/>
+            <HstSelect
+            v-model="error.variant"
+            title="variant"
+            :options="[
+                {value: 'filled', label: 'filled'},
+                {value: 'outlined', label: 'outlined'},
+                {value: 'underlined', label: 'underlined'},
+            ]"
+            />
         </template>
     </Variant>
 
@@ -277,25 +269,26 @@ const error : {
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| modelValue | string | '' | コンポーネントのv-model値です |
-| label | string | '' | ラベルに設定するテキストを指定します |
-| type | 'text'/'email'/'password' | 'text' | inputのtype属性を選択します |
-| variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
-| id | string | undefined | idを指定します |
-| name | string | undefined | nameを指定します |
-| error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
-| errorMessage | string/string[] | '' | コンポーネントをエラー状態にし、表示するメッセージを指定します。(slotsのerrorMessageが使用されている場合、このメッセージは表示されません) |
 | appendIcon | string | undefined | iconを入力フォームの右に追加する場合は指定します |
+| disabled | boolean | false | 非活性にする場合は指定します |
+| error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
+| errorMessage | string/string[] | '' | コンポーネントをエラー状態にし、表示するメッセージを指定します|
+| id | string | undefined | idを指定します |
+| label | string | '' | ラベルに設定するテキストを指定します |
+| maxErrors | string/number | undefined | 表示するエラーメッセージの数を制限します |
+| modelValue | string | '' | コンポーネントのv-model値です |
+| name | string | undefined | nameを指定します |
+| placeholder | string | '' | placeholderのメッセージを指定することができます |
 | prependIcon | string | undefined | iconを入力フォームの左に追加する場合は指定します |
 | readonly | boolean | false | 読み取り専用にする場合は指定します |
-| disabled | boolean | false | 非活性にする場合は指定します |
-| placeholder | string | '' | placeholderのメッセージを指定することができます |
+| type | 'text'/'email'/'password' | 'text' | inputのtype属性を選択します |
+| variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
 
 ## Slots
 
 | Name | Props (if scoped) | Description |
 | --- | --- | --- |
-| errorMessage |  | エラーの時のメッセージを表示する時に使用します(propsのerrorMessageが指定されている場合、こちらが優先されます) |
+| - | - | このコンポーネント独自のSlotはありません |
 
 ## Events
 

--- a/src/components/form/CTextField.vue
+++ b/src/components/form/CTextField.vue
@@ -95,8 +95,8 @@ const labelClass = computed(() => {
 </script>
 
 <template>
-<div class="w-full grid grid-cols-[auto_1fr_auto] gap-x-2 gap-y-1">
-    <div class="col-start-1 self-center">
+<div class="w-full grid grid-cols-[auto_1fr_auto] gap-y-1">
+    <div class="col-start-1 self-center pr-1">
         <c-svg-icon v-if="prependIcon" @click="$emit('click:prepend')" :icon="prependIcon" size="large" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-600'"/>
     </div>
     <div class="relative z-0 w-full col-start-2">
@@ -117,7 +117,7 @@ const labelClass = computed(() => {
             {{ label }}
         </label>
     </div>
-    <div class="col-start-3 self-center">
+    <div class="col-start-3 self-center pl-1">
         <c-svg-icon v-if="appendIcon" @click="$emit('click:append')" :icon="appendIcon" size="large" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-600'"/>
     </div>
     <div v-show="isError" class="text-xs text-[var(--jupiter-danger-text)] col-start-2">

--- a/src/components/form/CTextField.vue
+++ b/src/components/form/CTextField.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import {computed, useSlots} from 'vue';
+import {computed} from 'vue';
 import CSvgIcon from '@/components/dataDisplay/CSvgIcon.vue';
 
-const slots = useSlots()
+// const slots = useSlots()
 
 const props = withDefaults(defineProps<{
     modelValue: string
@@ -12,6 +12,7 @@ const props = withDefaults(defineProps<{
     name?:string
     error?: boolean
     errorMessage?: string|string[]
+    maxErrors?: string|number
     type?: 'text'|'email'|'password'
     appendIcon?: string
     prependIcon?: string
@@ -43,8 +44,11 @@ const inputValue = computed({
 })
 
 const formatedErrorMessage = computed(() => {
+    const max = Number(props.maxErrors)
     if(!props.errorMessage) return []
-    if(typeof props.errorMessage === 'string') return [props.errorMessage]
+    if(typeof props.errorMessage === 'string') return new Array(props.errorMessage)
+    if(!isNaN(max)) return props.errorMessage.filter((x, index) => index < max )
+    if(isNaN(max)) return props.errorMessage
     return props.errorMessage
 })
 
@@ -91,7 +95,7 @@ const labelClass = computed(() => {
 </script>
 
 <template>
-<div class="w-full grid grid-cols-[auto_1fr_auto] gap-2">
+<div class="w-full grid grid-cols-[auto_1fr_auto] gap-x-2 gap-y-1">
     <div class="col-start-1 self-center">
         <c-svg-icon v-if="prependIcon" @click="$emit('click:prepend')" :icon="prependIcon" size="large" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-600'"/>
     </div>
@@ -116,13 +120,10 @@ const labelClass = computed(() => {
     <div class="col-start-3 self-center">
         <c-svg-icon v-if="appendIcon" @click="$emit('click:append')" :icon="appendIcon" size="large" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-600'"/>
     </div>
-    <div v-show="isError" class="text-xs text-[var(--jupiter-danger-text)] pt-1 col-start-2">
-        <div v-if="!slots.errorMessage">
-            <p v-for="(msg,index) in formatedErrorMessage" :key="index">
-                {{ msg }}
-            </p>
-        </div>
-        <slot name="errorMessage"/>
+    <div v-show="isError" class="text-xs text-[var(--jupiter-danger-text)] col-start-2">
+        <p v-for="(msg,index) in formatedErrorMessage" :key="index">
+            {{ msg }}
+        </p>
     </div>
 </div>
 </template>

--- a/src/components/form/CTextarea.story.vue
+++ b/src/components/form/CTextarea.story.vue
@@ -67,11 +67,19 @@ const error: {
     label: string
     variant: 'filled'|'outlined'|'underlined'
     error: boolean
+    errorMessage: string|string[]|undefined
+    maxErrors: string|undefined
 } = reactive({
     modelValue: '',
     label: 'ラベル',
     variant: 'filled',
     error: true,
+    errorMessage: [
+        '入力が必須です',
+        '最大文字数制限(10文字)を超えています',
+        '半角英数字を入力してください'
+    ],
+    maxErrors: undefined,
 })
 </script>
 
@@ -220,14 +228,13 @@ const error: {
         :label="error.label"
         :variant="error.variant"
         :error="error.error"
-        clearable
-        >
-        <template v-slot:errorMessage>
-            ・入力が必須の項目です。
-        </template>
-        </c-textarea>
+        :error-message="error.errorMessage"
+        :max-errors="error.maxErrors"
+        />
         <template #controls>
             <HstCheckbox v-model="error.error" title="error"/>
+            <HstJson v-model="error.errorMessage" title="errorMessage"/>
+            <HstText v-model="error.maxErrors" title="maxErrors"/>
             <HstSelect
             v-model="error.variant"
             title="variant"
@@ -252,27 +259,29 @@ const error: {
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| modelValue | any | undefined | コンポーネントのv-model値です |
-| label | string | '' | ラベルに設定するテキストを指定します |
-| variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
-| id | string | undefined | idを指定します |
-| name | string | undefined | nameを指定します |
-| prependIcon | string | undefined | 入力フォームの左外側に表示させるiconを指定します |
 | appendIcon | string | undefined | 入力フォームの右外側に表示させるiconを指定します |
-| prependInnerIcon | string | undefined | 入力フォームの左内側に表示させるiconを指定します |
 | appendInnerIcon | string | undefined | 入力フォームの右内側に表示させるiconを指定します |
-| error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
 | clearable | boolean | false | 入力したテキストをクリアするボタンを追加する場合は指定します |
-| readonly | boolean | false | 読み取り専用にする場合は指定します |
 | disabled | boolean | false | 非活性にする場合は指定します |
+| error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
+| errorMessage | string/string[] | '' | コンポーネントをエラー状態にし、表示するメッセージを指定します|
+| id | string | undefined | idを指定します |
+| label | string | '' | ラベルに設定するテキストを指定します |
+| maxErrors | string/number | undefined | 表示するエラーメッセージの数を制限します |
+| modelValue | any | undefined | コンポーネントのv-model値です |
+| name | string | undefined | nameを指定します |
 | placeholder | string | '' | placeholderのメッセージを指定することができます |
+| prependIcon | string | undefined | 入力フォームの左外側に表示させるiconを指定します |
+| prependInnerIcon | string | undefined | 入力フォームの左内側に表示させるiconを指定します |
+| readonly | boolean | false | 読み取り専用にする場合は指定します |
 | rows | string/number | 2 | コントロールで見ることが可能なテキストの行数を指定できます |
+| variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
 
 ## Slots
 
 | Name | Props (if scoped) | Description |
 | --- | --- | --- |
-| errorMessage |  | エラーの時のメッセージを表示する時に使用します |
+| - | - | このコンポーネント独自のSlotはありません |
 
 ## Events
 

--- a/src/components/form/CTextarea.vue
+++ b/src/components/form/CTextarea.vue
@@ -127,8 +127,8 @@ const clear = () => {
 </script>
 
 <template>
-<div class="grid grid-cols-[auto_1fr_auto] gap-x-2 gap-y-1">
-    <div v-show="prependIcon" class="text-lg col-start-1 self-center">
+<div class="grid grid-cols-[auto_1fr_auto] gap-y-1">
+    <div v-show="prependIcon" class="text-lg col-start-1 self-center pr-1">
         <c-svg-icon :icon="prependIcon" @click="$emit('click:prepend')" size="medium" class="text-gray-500 cursor-pointer" />
     </div>
     <div :class="fieldClass">
@@ -157,7 +157,7 @@ const clear = () => {
             <c-svg-icon :icon="appendInnerIcon" @click="$emit('click:appendInner')" size="medium" class="text-gray-500 cursor-pointer" />
         </div>
     </div>
-    <div v-show="appendIcon" class="text-lg col-start-3 self-center">
+    <div v-show="appendIcon" class="text-lg col-start-3 self-center pl-1">
         <c-svg-icon :icon="appendIcon" @click="$emit('click:append')" size="medium" class="text-gray-500 cursor-pointer" />
     </div>
     <div v-show="isError" class="text-xs text-[var(--jupiter-danger-text)] col-start-2">

--- a/src/components/form/CTextarea.vue
+++ b/src/components/form/CTextarea.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
-import {computed, useSlots} from 'vue';
+import {computed} from 'vue';
 import { mdiClose } from '@mdi/js';
 import CSvgIcon from '@/components/dataDisplay/CSvgIcon.vue';
-
-const slots = useSlots()
 
 const props = withDefaults(defineProps<{
     modelValue: any
@@ -16,6 +14,8 @@ const props = withDefaults(defineProps<{
     prependInnerIcon?: string
     appendInnerIcon?: string
     error?: boolean
+    errorMessage?: string|string[]
+    maxErrors?: string|number
     clearable?: boolean
     readonly?: boolean
     disabled?: boolean
@@ -25,6 +25,7 @@ const props = withDefaults(defineProps<{
     label: '',
     variant: 'filled',
     error: false,
+    errorMessage: '',
     clearable: false,
     readonly: false,
     disabled: false, 
@@ -47,12 +48,27 @@ const textareaValue = computed({
     }
 })
 
+const formatedErrorMessage = computed(() => {
+    const max = Number(props.maxErrors)
+    if(!props.errorMessage) return []
+    if(typeof props.errorMessage === 'string') return new Array(props.errorMessage)
+    if(!isNaN(max)) return props.errorMessage.filter((x, index) => index < max )
+    if(isNaN(max)) return props.errorMessage
+    return props.errorMessage
+})
+
+const isError = computed(() => {
+    if(props.error) return true
+    if(formatedErrorMessage.value.length) return true
+    return false
+})
+
 const fieldClass = computed(() => {
     const base = [
         'group peer col-start-2 flex items-center w-full appearance-none focus:outline-none focus:ring-0 disabled:text-gray-500 opacity-100',
     ]
-    if(props.error) base.push('border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)] placeholder:text-[var(--jupiter-danger-text)] placeholder:opacity-0 focus:placeholder:opacity-50' )
-    if(!props.error) {
+    if(isError.value) base.push('border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)] placeholder:text-[var(--jupiter-danger-text)] placeholder:opacity-0 focus:placeholder:opacity-50' )
+    if(!isError.value) {
         base.push('placeholder:text-gray-400 placeholder:opacity-0 focus:placeholder:opacity-100 border-gray-300')
         base.push(props.readonly? 'focus-within:border-gray-900' : 'focus-within:border-blue-600')
     }
@@ -68,7 +84,7 @@ const textareaClass = computed(() => {
     const base = [
         'peer block w-full appearance-none focus:outline-none focus:ring-0 disabled:text-gray-500 opacity-100',
         props.label === '' ? 'placeholder:opacity-100': '',
-        props.error ? 'placeholder:text-[var(--jupiter-danger-text)] placeholder:opacity-0 focus:placeholder:opacity-50' : 'text-gray-900 read-only:text-gray-500 placeholder:text-gray-400 placeholder:opacity-0 focus:placeholder:opacity-100',
+        isError.value ? 'placeholder:text-[var(--jupiter-danger-text)] placeholder:opacity-0 focus:placeholder:opacity-50' : 'text-gray-900 read-only:text-gray-500 placeholder:text-gray-400 placeholder:opacity-0 focus:placeholder:opacity-100',
     ]
     if(props.variant === 'filled') base.push('rounded-t-lg rounded-b-none px-2.5 pb-1 pt-4 bg-gray-50')
     if(props.variant === 'outlined') base.push('px-2.5 pb-1.5 pt-4 bg-transparent rounded-lg')
@@ -81,8 +97,8 @@ const labelClass = computed(() => {
     const base = [
         'absolute text-sm duration-300 transform origin-[0] peer-focus:scale-75 whitespace-nowrap overflow-hidden pointer-events-none',
     ]
-    if(props.error) base.push('text-[var(--jupiter-danger-text)]')
-    if(!props.error) base.push('text-gray-500 peer-read-only:peer-focus:text-gray-900 peer-focus:text-blue-600')
+    if(isError.value) base.push('text-[var(--jupiter-danger-text)]')
+    if(!isError.value) base.push('text-gray-500 peer-read-only:peer-focus:text-gray-900 peer-focus:text-blue-600')
     if(props.variant === 'filled') base.push(
         '-translate-y-4 top-4 z-10 left-2.5 peer-focus:-translate-y-4',
         props.modelValue ? 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0' : 'scale-100 translate-y-0'
@@ -111,7 +127,7 @@ const clear = () => {
 </script>
 
 <template>
-<div class="grid grid-cols-[auto_1fr_auto] gap-2">
+<div class="grid grid-cols-[auto_1fr_auto] gap-x-2 gap-y-1">
     <div v-show="prependIcon" class="text-lg col-start-1 self-center">
         <c-svg-icon :icon="prependIcon" @click="$emit('click:prepend')" size="medium" class="text-gray-500 cursor-pointer" />
     </div>
@@ -144,8 +160,10 @@ const clear = () => {
     <div v-show="appendIcon" class="text-lg col-start-3 self-center">
         <c-svg-icon :icon="appendIcon" @click="$emit('click:append')" size="medium" class="text-gray-500 cursor-pointer" />
     </div>
-    <div v-show="error && slots.errorMessage" class="text-xs text-[var(--jupiter-danger-text)] pt-1 col-start-2">
-        <slot name="errorMessage"/>
+    <div v-show="isError" class="text-xs text-[var(--jupiter-danger-text)] col-start-2">
+        <p v-for="(msg,index) in formatedErrorMessage" :key="index">
+            {{ msg }}
+        </p>
     </div>
 </div>
 </template>


### PR DESCRIPTION
#73 

フォーム部品(TextField / Textarea / Select / Autocomplete / Checkbox)に、以下修正を行いました。
・slotsのerror-messageを廃止
・propsにerror-messageとmax-errorsを追加

## TextField
![スクリーンショット 2023-03-24 17 17 05](https://user-images.githubusercontent.com/101681088/227463202-0081249e-6f09-47f3-b435-fad5fb0600e9.png)

## 各ブラウザで確認済み

- Google Chrome
- FireFox
- Edge
- Safari
- Android Emulator
- iPhone Simulator
