### PR TITLE
TextField,Select, Autocomplete: アイコンをinputの中に表示できる機能はやはり欲しい

### DIFF
--- a/src/components/form/CAutocomplete.story.vue
+++ b/src/components/form/CAutocomplete.story.vue
@@ -320,8 +320,9 @@ const objectArrayFilter = (item:nameListType, searchText:string) => {
             item-value="id"
             :filter="objectArrayFilter"
             :variant="disabled.variant"
-            placeholder="入力"
+            placeholder="入力してください"
             :disabled="disabled.disabled"
+            label="ラベル"
             >
                 <template v-slot:selection="{item}">
                     {{ item.姓 }} {{ item.名 }}
@@ -356,6 +357,7 @@ const objectArrayFilter = (item:nameListType, searchText:string) => {
             :filter="objectArrayFilter"
             :variant="readonly.variant"
             :readonly="readonly.readonly"
+            label="ラベル"
             >
                 <template v-slot:selection="{item}">
                     {{ item.姓 }} {{ item.名 }}
@@ -394,6 +396,10 @@ const objectArrayFilter = (item:nameListType, searchText:string) => {
             :error="error.error"
             :error-message="error.errorMessage"
             :max-errors="error.maxErrors"
+            :append-icon="mdiComment"
+            :append-inner-icon="mdiComment"
+            :prepend-icon="mdiComment"
+            :prepend-inner-icon="mdiComment"
             >
                 <template v-slot:selection="{item}">
                     {{ item.姓 }} {{ item.名 }}

--- a/src/components/form/CAutocomplete.story.vue
+++ b/src/components/form/CAutocomplete.story.vue
@@ -430,6 +430,8 @@ const objectArrayFilter = (item:nameListType, searchText:string) => {
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
+| appendIcon | string | undefined | 入力フォームの右外側に表示させるiconを指定します |
+| appendInnerIcon | string | undefined | 入力フォームの右内側に表示させるiconを指定します |
 | clearable | boolean | false | 入力したテキストをクリアするボタンを追加する場合は指定します |
 | disabled | boolean | false | 非活性にする場合は指定します |
 | error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
@@ -443,6 +445,8 @@ const objectArrayFilter = (item:nameListType, searchText:string) => {
 | modelValue | any | null | コンポーネントのv-model値です |
 | name | string | undefined | nameを指定します |
 | placeholder | string | '' | placeholderのメッセージを指定することができます |
+| prependIcon | string | undefined | 入力フォームの左外側に表示させるiconを指定します |
+| prependInnerIcon | string | undefined | 入力フォームの左内側に表示させるiconを指定します |
 | readonly | boolean | false | 読み取り専用にする場合は指定します |
 | variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
 
@@ -459,4 +463,8 @@ const objectArrayFilter = (item:nameListType, searchText:string) => {
 | Name | Parameters | Description |
 | --- | --- | --- |
 | update:modelValue | - | コンポーネントのv-modelが変更されたときに発行されるイベントです |
+| click:append | - | 入力フォームの右外側に表示されたアイコンをクリックした時に発行されるイベントです |
+| click:prepend | - | 入力フォームの左外側に表示されたアイコンをクリックした時に発行されるイベントです |
+| click:appendInner | - | 入力フォームの右内側に表示されたアイコンをクリックした時に発行されるイベントです |
+| click:prependInner | - | 入力フォームの左内側に表示されたアイコンをクリックした時に発行されるイベントです |
 </docs>

--- a/src/components/form/CAutocomplete.story.vue
+++ b/src/components/form/CAutocomplete.story.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import {reactive} from "vue";
+import {logEvent} from "histoire/client";
+import { mdiComment } from '@mdi/js'
 import CBox from "@/components/layout/CBox.vue";
+import CStack from "@/components/layout/CStack.vue";
 import CAutocomplete from "@/components/form/CAutocomplete.vue";
 
 interface nameListType {
@@ -75,6 +78,15 @@ const clearable: {
     variant: 'filled'
 })
 
+const icons: {
+    modelValue: string
+    label: string
+    variant: 'filled'|'outlined'|'underlined'
+} = reactive({
+    modelValue: '',
+    label: 'ラベル',
+    variant: 'filled',
+})
 
 const disabled: {
     modelValue: string
@@ -228,6 +240,69 @@ const objectArrayFilter = (item:nameListType, searchText:string) => {
             />
             <HstSelect
             v-model="clearable.variant"
+            title="variant"
+            :options="[
+                {value: 'filled', label: 'filled'},
+                {value: 'outlined', label: 'outlined'},
+                {value: 'underlined', label: 'underlined'},
+            ]"
+            />
+        </template>
+    </Variant>
+    <Variant title="Icons" auto-props-disabled>
+        <c-box padding="large">
+            <c-stack>
+                <c-autocomplete
+                v-model="icons.modelValue"
+                :items="string.bloodType"
+                :filter="stringArrayFilter"
+                label="prepend-icon"
+                :variant="icons.variant"
+                :prepend-icon="mdiComment"
+                placeholder="placeholder"
+                clearable
+                @click:prepend="logEvent('fire click:prepend', $event)"
+                >
+                </c-autocomplete>
+                <c-autocomplete
+                v-model="icons.modelValue"
+                :items="string.bloodType"
+                :filter="stringArrayFilter"
+                label="append-icon"
+                :variant="icons.variant"
+                :append-icon="mdiComment"
+                clearable
+                @click:append="logEvent('fire click:append', $event)"
+                >
+                </c-autocomplete>
+                <c-autocomplete
+                v-model="icons.modelValue"
+                :items="string.bloodType"
+                :filter="stringArrayFilter"
+                label="prepend-inner-icon"
+                :variant="icons.variant"
+                :prepend-inner-icon="mdiComment"
+                clearable
+                @click:prepend-inner="logEvent('fire click:prepend-inner', $event)"
+                >
+                </c-autocomplete>
+                <c-autocomplete
+                v-model="icons.modelValue"
+                :items="string.bloodType"
+                :filter="stringArrayFilter"
+                label="append-inner-icon"
+                :variant="icons.variant"
+                :append-inner-icon="mdiComment"
+                clearable
+                @click:append-inner="logEvent('fire click:append-inner', $event)"
+                >
+                </c-autocomplete>
+            </c-stack>
+        </c-box>
+        <template #controls>
+            <HstText v-model="icons.modelValue" title="modelValue"/>
+            <HstSelect
+            v-model="icons.variant"
             title="variant"
             :options="[
                 {value: 'filled', label: 'filled'},

--- a/src/components/form/CAutocomplete.story.vue
+++ b/src/components/form/CAutocomplete.story.vue
@@ -396,10 +396,6 @@ const objectArrayFilter = (item:nameListType, searchText:string) => {
             :error="error.error"
             :error-message="error.errorMessage"
             :max-errors="error.maxErrors"
-            :append-icon="mdiComment"
-            :append-inner-icon="mdiComment"
-            :prepend-icon="mdiComment"
-            :prepend-inner-icon="mdiComment"
             >
                 <template v-slot:selection="{item}">
                     {{ item.姓 }} {{ item.名 }}

--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -70,7 +70,7 @@ const isError = computed(() => {
 
 const fieldClass = computed(() => {
     const base = [
-        'group peer relative col-start-2 flex items-center w-full appearance-none focus:outline-none focus:ring-0 disabled:text-gray-500 opacity-100',
+        'group peer relative col-start-2 flex items-center w-full appearance-none focus:outline-none focus:ring-0 opacity-100',
         props.readonly ? 'focus-within:border-gray-900' : 'focus-within:border-blue-600',
         isError.value
         ? 'border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)]' 
@@ -138,7 +138,7 @@ const clearIconDisplay = computed(() => {
     return props.clearable && (data.inputText!=='' || Object.keys(selectionItem.value).length) && !props.readonly && !props.disabled
 })
 
-const toggleIconDisplay = computed(() => {
+const menuIconDisplay = computed(() => {
     return !props.readonly && !props.disabled
 })
 
@@ -225,14 +225,14 @@ watchEffect(() => {
         <div v-show="clearIconDisplay" class="pt-2">
             <c-svg-icon :icon="mdiClose" @click="clear" class="text-gray-500 cursor-pointer" />
         </div>
-        <div v-show="toggleIconDisplay" class="pt-2">
+        <div v-show="menuIconDisplay" class="pt-2">
             <c-svg-icon :icon="data.isActive ? mdiMenuUp : mdiMenuDown" @click="toggleDropdownList" :class="isError ? 'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
         </div>
         <div v-show="appendInnerIcon" class="pt-2 pl-1 text-lg">
             <c-svg-icon :icon="appendInnerIcon" @click="$emit('click:appendInner')" size="medium" class="text-gray-500 cursor-pointer" />
         </div>
 
-        <div v-show="data.isActive" class="absolute left-0 top-full pt-1 z-50 w-full rounded peer-read-only:hidden">
+        <div v-show="data.isActive" class="absolute left-0 top-full pt-0.5 z-50 w-full rounded peer-read-only:hidden">
             <ul class="overflow-auto divide-y-2 divide-gray-100 rounded-b bg-white shadow-lg z-50 max-h-60">
                 <template v-if="dropdownListItems.length > 0">
                     <li v-for="(item,index) in dropdownListItems" :key="index" @click.stop="selectItem(item)" :class="liClass(item)" class="py-2 px-3 min-w-full text-gray-700 cursor-pointer hover:bg-gray-100">

--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -70,12 +70,12 @@ const isError = computed(() => {
 
 const fieldClass = computed(() => {
     const base = [
-        'group peer relative col-start-2 flex items-center w-full appearance-none focus:outline-none focus:ring-0 opacity-100',
-        props.readonly ? 'focus-within:border-gray-900' : 'focus-within:border-blue-600',
-        isError.value
-        ? 'border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)]' 
-        : 'border-gray-300',
+        'peer relative col-start-2 flex items-center w-full appearance-none focus:outline-none focus:ring-0 opacity-100',
     ]
+    if(isError.value) base.push('border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)]')
+    if(!isError.value && props.readonly) base.push('focus-within:border-gray-900 border-gray-300') 
+    if(!isError.value && !props.readonly) base.push('focus-within:border-blue-600 border-gray-300')
+
     if(props.variant === 'filled') base.push('rounded-t-lg rounded-b-none px-2.5 bg-gray-50 border-0 border-b-2')
     if(props.variant === 'outlined') base.push('px-2.5 bg-transparent rounded-lg border')
     if(props.variant === 'underlined') base.push('rounded-none px-0 bg-transparent border-0 border-b-2')
@@ -85,7 +85,7 @@ const fieldClass = computed(() => {
 
 const inputClass = computed(() => {
     return [
-        'peer w-full focus:outline-none bg-transparent',
+        'peer w-full text-gray-900 focus:outline-none focus:ring-0 bg-transparent opacity-100',
         props.modelValue ? 'placeholder:opacity-0' : props.label ? 'placeholder:opacity-0 focus:placeholder:opacity-100' : 'opacity-100',
         props.variant === 'filled' ? 'pt-4 pb-1' : '',
         props.variant === 'outlined' ? 'pt-4 pb-1.5' : '',
@@ -116,6 +116,13 @@ const labelClass = computed(() => {
         ? 'scale-100 translate-y-0' 
         : props.placeholder ? 'scale-75' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
     return base
+})
+
+const selectionClass = computed(() => {
+    return [
+        'pb-1 pt-4 whitespace-nowrap',
+        props.readonly || props.disabled ? 'text-gray-500' : 'text-gray-900',
+    ]
 })
 
 const dropdownListItems = computed(() => {
@@ -187,15 +194,15 @@ watchEffect(() => {
 </script>
 <template>
 <div @mouseover="data.isHover = true" @mouseleave="data.isHover = false" class="relative grid grid-cols-[auto_1fr_auto] gap-y-1">
-    <div v-show="prependIcon" class="text-lg col-start-1 pt-4 pr-1">
-        <c-svg-icon :icon="prependIcon" @click="$emit('click:prepend')" size="medium" class="text-gray-500 cursor-pointer" />
+    <div v-show="prependIcon" class="text-lg col-start-1 my-auto pt-1.5 pr-1">
+        <c-svg-icon :icon="prependIcon" @click="$emit('click:prepend')" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
     </div>
     <div :class="fieldClass">
-        <div v-show="prependInnerIcon" class="pt-2 pr-2 text-lg">
-            <c-svg-icon :icon="prependInnerIcon" @click="$emit('click:prependInner')" size="medium" class="text-gray-500 cursor-pointer" />
+        <div v-show="prependInnerIcon" class="my-auto pt-2 pr-2 text-lg">
+            <c-svg-icon :icon="prependInnerIcon" @click="$emit('click:prependInner')" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
         </div>
         <div class="relative w-full flex">
-            <div v-if="selectionSlotDisplay" class="pb-1 pt-4 whitespace-nowrap group-read-only:text-gray-500 group-disabled:text-gray-500">
+            <div v-if="selectionSlotDisplay" :class="selectionClass">
                 <slot name="selection" :item="selectionItem">
                     {{ typeof selectionItem === "object" ? selectionItem[itemValue] : selectionItem }}
                 </slot>
@@ -228,8 +235,8 @@ watchEffect(() => {
         <div v-show="menuIconDisplay" class="pt-2">
             <c-svg-icon :icon="data.isActive ? mdiMenuUp : mdiMenuDown" @click="toggleDropdownList" :class="isError ? 'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
         </div>
-        <div v-show="appendInnerIcon" class="pt-2 pl-1 text-lg">
-            <c-svg-icon :icon="appendInnerIcon" @click="$emit('click:appendInner')" size="medium" class="text-gray-500 cursor-pointer" />
+        <div v-show="appendInnerIcon" class="my-auto pt-2 pl-1 text-lg">
+            <c-svg-icon :icon="appendInnerIcon" @click="$emit('click:appendInner')" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
         </div>
 
         <div v-show="data.isActive" class="absolute left-0 top-full pt-0.5 z-50 w-full rounded peer-read-only:hidden">
@@ -249,8 +256,8 @@ watchEffect(() => {
             </ul>
         </div>
     </div>
-    <div v-show="appendIcon" class="text-lg col-start-3 pt-4 pl-1">
-        <c-svg-icon :icon="appendIcon" @click="$emit('click:append')" size="medium" class="text-gray-500 cursor-pointer" />
+    <div v-show="appendIcon" class="my-auto text-lg col-start-3 pt-1.5 pl-1">
+        <c-svg-icon :icon="appendIcon" @click="$emit('click:append')" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
     </div>
     <div v-if="isError" class="text-xs text-[var(--jupiter-danger-text)] pt-1 col-start-2">
         <p v-for="(msg,index) in formatedErrorMessage" :key="index">

--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -72,7 +72,7 @@ const fieldClass = computed(() => {
     const base = [
         'peer relative col-start-2 flex items-center w-full appearance-none focus:outline-none focus:ring-0 opacity-100',
     ]
-    if(isError.value) base.push('border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)]')
+    if(isError.value) base.push('border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-outline-focus)]')
     if(!isError.value && props.readonly) base.push('focus-within:border-gray-900 border-gray-300') 
     if(!isError.value && !props.readonly) base.push('focus-within:border-blue-600 border-gray-300')
 
@@ -101,17 +101,17 @@ const labelClass = computed(() => {
     if(!isError.value) base.push('text-gray-500 peer-read-only:peer-focus:text-gray-900 peer-focus:text-blue-600')
 
     if(props.variant === 'filled') base.push(
-        '-translate-y-4 top-4 z-10 peer-focus:-translate-y-4', 
+        '-translate-y-4 top-4 peer-focus:-translate-y-4', 
         !props.modelValue && !data.inputText
         ? 'scale-100 translate-y-0' 
         : props.placeholder ? 'scale-75' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
     if(props.variant === 'outlined') base.push(
-        '-translate-y-4 top-4 z-10 peer-focus:-translate-y-4', 
+        '-translate-y-4 top-4 peer-focus:-translate-y-4', 
         !props.modelValue && !data.inputText
         ? 'scale-100 translate-y-0' 
         : props.placeholder ? 'scale-75' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
     if(props.variant === 'underlined') base.push(
-        '-translate-y-5 top-3 z-10 peer-focus:left-0 peer-focus:-translate-y-5', 
+        '-translate-y-5 top-3 peer-focus:left-0 peer-focus:-translate-y-5', 
         !props.modelValue && !data.inputText
         ? 'scale-100 translate-y-0' 
         : props.placeholder ? 'scale-75' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
@@ -170,6 +170,7 @@ const selectItem = (option: any) => {
 
 const openDropdownList = () => {
     if(props.readonly) return 
+    if(props.disabled) return
     data.isActive = true
 }
 
@@ -179,6 +180,8 @@ const closeDropdownList = () => {
 }
 
 const toggleDropdownList = () => {
+    if(props.readonly) return
+    if(props.disabled) return
     data.isActive = !data.isActive
 }
 
@@ -202,7 +205,7 @@ watchEffect(() => {
             <c-svg-icon :icon="prependInnerIcon" @click="$emit('click:prependInner')" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
         </div>
         <div class="relative w-full flex">
-            <div v-if="selectionSlotDisplay" :class="selectionClass">
+            <div v-if="selectionSlotDisplay" @click="toggleDropdownList" :class="selectionClass">
                 <slot name="selection" :item="selectionItem">
                     {{ typeof selectionItem === "object" ? selectionItem[itemValue] : selectionItem }}
                 </slot>

--- a/src/components/form/CAutocomplete.vue
+++ b/src/components/form/CAutocomplete.vue
@@ -19,6 +19,10 @@ const props = withDefaults(defineProps<{
     maxErrors?: string|number
     clearable?: boolean
     placeholder?: string
+    prependIcon?: string
+    appendIcon?: string
+    prependInnerIcon?: string
+    appendInnerIcon?: string
 }>(), {
     itemValue: '',
     label: '',
@@ -33,6 +37,10 @@ const props = withDefaults(defineProps<{
 
 const emits = defineEmits<{
     (e: 'update:modelValue', value: any): void
+    (e: 'click:prepend'): void
+    (e: 'click:append'): void
+    (e: 'click:prependInner'): void
+    (e: 'click:appendInner'): void
 }>()
 
 const data: {
@@ -62,12 +70,11 @@ const isError = computed(() => {
 
 const fieldClass = computed(() => {
     const base = [
-        'group peer flex items-center w-full appearance-none focus:outline-none focus:ring-0 disabled:text-gray-500 opacity-100',
+        'group peer relative col-start-2 flex items-center w-full appearance-none focus:outline-none focus:ring-0 disabled:text-gray-500 opacity-100',
         props.readonly ? 'focus-within:border-gray-900' : 'focus-within:border-blue-600',
         isError.value
-        ? 'border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)] text-[var(--jupiter-danger-text)] placeholder:text-[var(--jupiter-danger-text)] placeholder:opacity-0 focus:placeholder:opacity-50' 
-        : 'placeholder:text-gray-400 placeholder:opacity-0 focus:placeholder:opacity-100 border-gray-300',
-        props.clearable ? 'pr-14' : '',
+        ? 'border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)]' 
+        : 'border-gray-300',
     ]
     if(props.variant === 'filled') base.push('rounded-t-lg rounded-b-none px-2.5 bg-gray-50 border-0 border-b-2')
     if(props.variant === 'outlined') base.push('px-2.5 bg-transparent rounded-lg border')
@@ -79,8 +86,7 @@ const fieldClass = computed(() => {
 const inputClass = computed(() => {
     return [
         'peer w-full focus:outline-none bg-transparent',
-        props.label !== '' ? 'placeholder:opacity-0 focus:placeholder:opacity-100': '',
-        props.modelValue ? 'placeholder:opacity-0' : 'opacity-100',
+        props.modelValue ? 'placeholder:opacity-0' : props.label ? 'placeholder:opacity-0 focus:placeholder:opacity-100' : 'opacity-100',
         props.variant === 'filled' ? 'pt-4 pb-1' : '',
         props.variant === 'outlined' ? 'pt-4 pb-1.5' : '',
         props.variant === 'underlined' ? 'pt-2.5 pb-1' : '',        
@@ -89,14 +95,26 @@ const inputClass = computed(() => {
 
 const labelClass = computed(() => {
     const base = [
-        'absolute text-sm duration-300 transform scale-75 origin-[0] peer-focus:scale-75 whitespace-nowrap overflow-hidden pointer-events-none',
+        'absolute text-sm duration-300 transform origin-[0] peer-focus:scale-75 whitespace-nowrap overflow-hidden pointer-events-none',
     ]
     if(isError.value) base.push('text-[var(--jupiter-danger-text)]')
     if(!isError.value) base.push('text-gray-500 peer-read-only:peer-focus:text-gray-900 peer-focus:text-blue-600')
 
-    if(props.variant === 'filled') base.push('-translate-y-4 top-4 z-10 left-2.5 peer-focus:-translate-y-4', !props.modelValue?'peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0':'')
-    if(props.variant === 'outlined') base.push('-translate-y-4 top-4 z-10 px-2 peer-focus:px-2 peer-focus:-translate-y-4 left-1 top-4', !props.modelValue?'peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-0':'')
-    if(props.variant === 'underlined') base.push('-translate-y-5 top-3 z-10 peer-focus:left-0 peer-focus:-translate-y-5', !props.modelValue?'peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0':'')
+    if(props.variant === 'filled') base.push(
+        '-translate-y-4 top-4 z-10 peer-focus:-translate-y-4', 
+        !props.modelValue && !data.inputText
+        ? 'scale-100 translate-y-0' 
+        : props.placeholder ? 'scale-75' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
+    if(props.variant === 'outlined') base.push(
+        '-translate-y-4 top-4 z-10 peer-focus:-translate-y-4', 
+        !props.modelValue && !data.inputText
+        ? 'scale-100 translate-y-0' 
+        : props.placeholder ? 'scale-75' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
+    if(props.variant === 'underlined') base.push(
+        '-translate-y-5 top-3 z-10 peer-focus:left-0 peer-focus:-translate-y-5', 
+        !props.modelValue && !data.inputText
+        ? 'scale-100 translate-y-0' 
+        : props.placeholder ? 'scale-75' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
     return base
 })
 
@@ -117,7 +135,11 @@ const selectionItem = computed(() => {
 })
 
 const clearIconDisplay = computed(() => {
-    return props.clearable && (data.inputText!=='' || Object.keys(selectionItem.value).length)
+    return props.clearable && (data.inputText!=='' || Object.keys(selectionItem.value).length) && !props.readonly && !props.disabled
+})
+
+const toggleIconDisplay = computed(() => {
+    return !props.readonly && !props.disabled
 })
 
 const selectionSlotDisplay = computed(() => {
@@ -140,6 +162,7 @@ const selectItem = (option: any) => {
 }
 
 const openDropdownList = () => {
+    if(props.readonly) return 
     data.isActive = true
 }
 
@@ -163,36 +186,53 @@ watchEffect(() => {
 
 </script>
 <template>
-<div @mouseover="data.isHover = true" @mouseleave="data.isHover = false" class="relative w-auto">
-    <fieldset v-bind="$attrs" :class="fieldClass">
-        <div class="pb-1 pt-4 whitespace-nowrap group-read-only:text-gray-500 group-disabled:text-gray-500">
-            <slot v-if="selectionSlotDisplay" name="selection" :item="selectionItem">
-                {{ typeof selectionItem === "object" ? selectionItem[itemValue] : selectionItem }}
-            </slot>
+<div @mouseover="data.isHover = true" @mouseleave="data.isHover = false" class="relative grid grid-cols-[auto_1fr_auto] gap-y-1">
+    <div v-show="prependIcon" class="text-lg col-start-1 pt-4 pr-1">
+        <c-svg-icon :icon="prependIcon" @click="$emit('click:prepend')" size="medium" class="text-gray-500 cursor-pointer" />
+    </div>
+    <div :class="fieldClass">
+        <div v-show="prependInnerIcon" class="pt-2 pr-2 text-lg">
+            <c-svg-icon :icon="prependInnerIcon" @click="$emit('click:prependInner')" size="medium" class="text-gray-500 cursor-pointer" />
         </div>
-        <input 
-            v-model="data.inputText"
-            v-bind="$attrs"
-            @focus="openDropdownList" 
-            @blur="closeDropdownList"
-            @keyup.delete="clear"
-            type="text" 
-            :id="id"
-            :name="name"
-            :readonly="readonly"
-            :disabled="disabled"
-            :placeholder="placeholder"
-            :class="inputClass" 
-            autocomplete="off"
-        />
-        <label 
-            :class="labelClass"
-        >
-            {{ label }}
-        </label>
-        <c-svg-icon v-show="clearIconDisplay" :icon="mdiClose" @click="clear" class="absolute inset-y-auto right-7 text-gray-500 peer-disabled:hidden peer-read-only:hidden cursor-pointer" />
-        <c-svg-icon :icon="data.isActive ? mdiMenuUp : mdiMenuDown" @click="toggleDropdownList" class="absolute inset-y-auto right-1 peer-disabled:hidden peer-read-only:hidden" :class="isError ? 'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
-        <div v-show="data.isActive" class="absolute left-0 top-full z-50 w-full rounded peer-read-only:hidden">
+        <div class="relative w-full flex">
+            <div v-if="selectionSlotDisplay" class="pb-1 pt-4 whitespace-nowrap group-read-only:text-gray-500 group-disabled:text-gray-500">
+                <slot name="selection" :item="selectionItem">
+                    {{ typeof selectionItem === "object" ? selectionItem[itemValue] : selectionItem }}
+                </slot>
+            </div>
+            <input
+                v-model="data.inputText"
+                v-bind="$attrs"
+                @focus="openDropdownList"
+                @blur="closeDropdownList"
+                @keyup.delete="clear"
+                type="text"
+                :id="id"
+                :name="name"
+                :readonly="readonly"
+                :disabled="disabled"
+                :placeholder="placeholder"
+                :class="inputClass"
+                autocomplete="off"
+            />
+            <label
+                :class="labelClass"
+            >
+                {{ label }}
+            </label>
+
+        </div>
+        <div v-show="clearIconDisplay" class="pt-2">
+            <c-svg-icon :icon="mdiClose" @click="clear" class="text-gray-500 cursor-pointer" />
+        </div>
+        <div v-show="toggleIconDisplay" class="pt-2">
+            <c-svg-icon :icon="data.isActive ? mdiMenuUp : mdiMenuDown" @click="toggleDropdownList" :class="isError ? 'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
+        </div>
+        <div v-show="appendInnerIcon" class="pt-2 pl-1 text-lg">
+            <c-svg-icon :icon="appendInnerIcon" @click="$emit('click:appendInner')" size="medium" class="text-gray-500 cursor-pointer" />
+        </div>
+
+        <div v-show="data.isActive" class="absolute left-0 top-full pt-1 z-50 w-full rounded peer-read-only:hidden">
             <ul class="overflow-auto divide-y-2 divide-gray-100 rounded-b bg-white shadow-lg z-50 max-h-60">
                 <template v-if="dropdownListItems.length > 0">
                     <li v-for="(item,index) in dropdownListItems" :key="index" @click.stop="selectItem(item)" :class="liClass(item)" class="py-2 px-3 min-w-full text-gray-700 cursor-pointer hover:bg-gray-100">
@@ -208,11 +248,14 @@ watchEffect(() => {
                 </li>
             </ul>
         </div>
-    </fieldset>
-</div>
-<div v-if="isError" class="text-xs text-[var(--jupiter-danger-text)] pt-1">
-    <p v-for="(msg,index) in formatedErrorMessage" :key="index">
-        {{ msg }}
-    </p>
+    </div>
+    <div v-show="appendIcon" class="text-lg col-start-3 pt-4 pl-1">
+        <c-svg-icon :icon="appendIcon" @click="$emit('click:append')" size="medium" class="text-gray-500 cursor-pointer" />
+    </div>
+    <div v-if="isError" class="text-xs text-[var(--jupiter-danger-text)] pt-1 col-start-2">
+        <p v-for="(msg,index) in formatedErrorMessage" :key="index">
+            {{ msg }}
+        </p>
+    </div>
 </div>
 </template>

--- a/src/components/form/CSelect.story.vue
+++ b/src/components/form/CSelect.story.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { computed, reactive } from 'vue';
+import {logEvent} from "histoire/client";
+import { mdiComment } from '@mdi/js'
 import CSelect from '@/components/form/CSelect.vue';
 import CBox from '@/components/layout/CBox.vue';
+import CStack from '@/components/layout/CStack.vue';
 import CCheckbox from '@/components/form/CCheckbox.vue';
 
 const data: {
@@ -136,6 +139,21 @@ const clearable: {
     ],
     label: 'ラベル',
     clearable: true,
+    variant: 'filled',
+})
+
+const icons: {
+    modelValue: string
+    bloodTypeList: string[]
+    variant: 'filled'|'outlined'|'underlined'
+} = reactive({
+    modelValue: '',
+    bloodTypeList: [
+        'A型',
+        'B型',
+        'O型',
+        'AB型',
+    ],
     variant: 'filled',
 })
 
@@ -331,6 +349,59 @@ const customToggle = () => {
             <HstCheckbox v-model="clearable.clearable" title="clearable"/>
             <HstSelect
             v-model="clearable.variant"
+            title="variant"
+            :options="[
+                {value: 'filled', label: 'filled'},
+                {value: 'outlined', label: 'outlined'},
+                {value: 'underlined', label: 'underlined'},
+            ]"
+            />
+        </template>
+    </Variant>
+    <Variant title="Icons" auto-props-disabled>
+        <c-box>
+            <c-stack>
+                <c-select
+                    v-model="icons.modelValue"
+                    :items="icons.bloodTypeList"
+                    label="prepend-icon"
+                    :variant="icons.variant"
+                    :prepend-icon="mdiComment"
+                    clearable
+                    @click:prepend="logEvent('fire click:prepend', $event)"
+                />
+                <c-select
+                    v-model="icons.modelValue"
+                    :items="icons.bloodTypeList"
+                    label="append-icon"
+                    :variant="icons.variant"
+                    :append-icon="mdiComment"
+                    clearable
+                    @click:append="logEvent('fire click:append', $event)"
+                />
+                <c-select
+                    v-model="icons.modelValue"
+                    :items="icons.bloodTypeList"
+                    label="prepend-inner-icon"
+                    :variant="icons.variant"
+                    :prepend-inner-icon="mdiComment"
+                    clearable
+                    @click:prepend-inner="logEvent('fire click:prepend-inner', $event)"
+                />
+                <c-select
+                    v-model="icons.modelValue"
+                    :items="icons.bloodTypeList"
+                    label="append-inner-icon"
+                    :variant="icons.variant"
+                    :append-inner-icon="mdiComment"
+                    clearable
+                    @click:append-inner="logEvent('fire click:append-inner', $event)"
+                />
+            </c-stack>
+        </c-box>
+        <template #controls>
+            <HstSelect
+            v-model="icons.variant"
             title="variant"
             :options="[
                 {value: 'filled', label: 'filled'},

--- a/src/components/form/CSelect.story.vue
+++ b/src/components/form/CSelect.story.vue
@@ -497,6 +497,8 @@ const customToggle = () => {
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
+| appendIcon | string | undefined | 入力フォームの右外側に表示させるiconを指定します |
+| appendInnerIcon | string | undefined | 入力フォームの右内側に表示させるiconを指定します |
 | clearable | boolean | false | 選択した値をクリアするボタンを追加する場合は指定します |
 | disabled | boolean | false | 非活性にする場合は指定します |
 | error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
@@ -510,6 +512,8 @@ const customToggle = () => {
 | multiple | boolean | false | 複数選択を可能にする場合は指定します |
 | name | string | undefined | nameを指定します |
 | placeholder | string | undefined | placeholderに表示するメッセージを指定します |
+| prependIcon | string | undefined | 入力フォームの左外側に表示させるiconを指定します |
+| prependInnerIcon | string | undefined | 入力フォームの左内側に表示させるiconを指定します |
 | readonly | boolean | false | 読み取り専用にする場合は指定します |
 | variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
 
@@ -527,4 +531,8 @@ const customToggle = () => {
 | Name | Parameters | Description |
 | --- | --- | --- |
 | update:modelValue | - | コンポーネントのv-modelが変更されたときに発行されるイベントです |
+| click:append | - | 入力フォームの右外側に表示されたアイコンをクリックした時に発行されるイベントです |
+| click:prepend | - | 入力フォームの左外側に表示されたアイコンをクリックした時に発行されるイベントです |
+| click:appendInner | - | 入力フォームの右内側に表示されたアイコンをクリックした時に発行されるイベントです |
+| click:prependInner | - | 入力フォームの左内側に表示されたアイコンをクリックした時に発行されるイベントです |
 </docs>

--- a/src/components/form/CSelect.story.vue
+++ b/src/components/form/CSelect.story.vue
@@ -475,7 +475,7 @@ const customToggle = () => {
             <HstJson v-model="error.errorMessage" title="errorMessage"/>
             <HstText v-model="error.maxErrors" title="maxErrors"/>
             <HstSelect
-            v-model="data.variant"
+            v-model="error.variant"
             title="variant"
             :options="[
                 {value: 'filled', label: 'filled'},

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -79,12 +79,11 @@ const isError = computed(() => {
 
 const fieldClass = computed(() => {
     const base = [
-        'group peer relative col-start-2 flex items-center w-full appearance-none focus:outline-none focus:ring-0 opacity-100',
-        props.readonly ? 'focus-within:border-gray-900' : 'focus-within:border-blue-600',
-        isError.value 
-        ? 'border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)] text-[var(--jupiter-danger-text)] placeholder:text-[var(--jupiter-danger-text)] placeholder:opacity-0 focus:placeholder:opacity-50' 
-        : 'placeholder:text-gray-400 placeholder:opacity-0 focus:placeholder:opacity-100 border-gray-300',
+        'peer relative col-start-2 flex items-center w-full appearance-none focus:outline-none focus:ring-0 opacity-100',
     ]
+    if(isError.value) base.push('border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)]')
+    if(!isError.value && props.readonly) base.push('focus-within:border-gray-900 border-gray-300') 
+    if(!isError.value && !props.readonly) base.push('focus-within:border-blue-600 border-gray-300')
     if(props.variant === 'filled') base.push('min-h-[2.7rem] rounded-t-lg rounded-b-none px-2.5 bg-gray-50 border-0 border-b-2')
     if(props.variant === 'outlined') base.push('min-h-[2.8rem] px-2.5 bg-transparent rounded-lg border')
     if(props.variant === 'underlined') base.push('min-h-[2.3rem] rounded-none px-0 bg-transparent border-0 border-b-2')
@@ -93,15 +92,16 @@ const fieldClass = computed(() => {
 })
 
 const inputClass = computed(() => {
-    return [
+    const base = [
         'peer w-full focus:outline-none bg-transparent',
-        props.label === '' 
-        ? 'placeholder:opacity-100'
-        : !props.modelValue || !props.modelValue.length ? props.readonly? 'placeholder:opacity-0' :'placeholder:opacity-0 focus:placeholder:opacity-100' : 'placeholder:opacity-0',
-        props.variant === 'filled' ? 'pt-4 pb-1' : '',
-        props.variant === 'outlined' ? 'pt-4 pb-1.5' : '',
-        props.variant === 'underlined' ? 'pt-2.5 pb-1' : '',        
     ]
+    if(!props.label) base.push('placeholder:opacity-100')
+    if(props.label && (!props.modelValue || !props.modelValue.length)) base.push('placeholder:opacity-0 focus:placeholder:opacity-100')
+    if(props.label && (props.modelValue || props.modelValue.length)) base.push('placeholder:opacity-0')
+    if(props.variant === 'filled') base.push('pt-4 pb-1')
+    if(props.variant === 'outlined') base.push('pt-4 pb-1.5')
+    if(props.variant === 'underlined') base.push('pt-2.5 pb-1')
+    return base
 })
 
 const labelClass = computed(() => {
@@ -135,10 +135,11 @@ const labelClass = computed(() => {
 
 const selectionClass = computed(() => {
     return [
-        'pb-1 pr-4 whitespace-nowrap cursor-pointer group-read-only:text-gray-500 group-disabled:text-gray-500',
+        'pb-1 pr-4 whitespace-nowrap cursor-pointer',
         props.variant === 'filled' ? 'pt-4' : '',
         props.variant === 'outlined' ? 'pt-4' : '',
         props.variant === 'underlined' ? 'pt-2.5' : '',
+        props.readonly || props.disabled ? 'text-gray-500' : 'text-gray-900',
     ]
 })
 
@@ -230,12 +231,12 @@ const clear = () => {
 
 <template>
 <div @mouseover="data.isHover = true" @mouseleave="data.isHover = false" class="relative w-auto grid grid-cols-[auto_1fr_auto] gap-y-1">
-    <div v-show="prependIcon" class="text-lg col-start-1 pt-4 pr-1">
-        <c-svg-icon :icon="prependIcon" @click="$emit('click:prepend')" size="medium" class="text-gray-500 cursor-pointer" />
+    <div v-show="prependIcon" class="my-auto text-lg col-start-1 pt-1.5 pr-1">
+        <c-svg-icon :icon="prependIcon" @click="$emit('click:prepend')" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
     </div>
     <div :class="fieldClass">
-        <div v-show="prependInnerIcon" class="pt-2 pr-2 text-lg">
-            <c-svg-icon :icon="prependInnerIcon" @click="$emit('click:prependInner')" size="medium" class="text-gray-500 cursor-pointer" />
+        <div v-show="prependInnerIcon" class="my-auto pt-2 pr-2 text-lg">
+            <c-svg-icon :icon="prependInnerIcon" @click="$emit('click:prependInner')" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
         </div>
         <div class="relative w-full flex">
             <div v-show="selectionSlotDisplay && Array.isArray(selectionItem)" @click="toggleDropdownList" :class="selectionClass">
@@ -274,8 +275,8 @@ const clear = () => {
         <div v-show="menuIconDisplay" class="pt-2">
             <c-svg-icon :icon="data.isActive ? mdiMenuUp : mdiMenuDown" @click="toggleDropdownList" :class="isError ? 'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
         </div>
-        <div v-show="appendInnerIcon" class="pt-2 pl-1 text-lg">
-            <c-svg-icon :icon="appendInnerIcon" @click="$emit('click:appendInner')" size="medium" class="text-gray-500 cursor-pointer" />
+        <div v-show="appendInnerIcon" class="my-auto pt-2 pl-1 text-lg">
+            <c-svg-icon :icon="appendInnerIcon" @click="$emit('click:appendInner')" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
         </div>
         <div v-show="data.isActive" class="absolute left-0 top-full pt-0.5 z-50 w-full rounded">
             <ul class="overflow-auto divide-y-2 divide-gray-100 rounded-b bg-white shadow-lg z-50 max-h-60">
@@ -302,8 +303,8 @@ const clear = () => {
             </ul>
         </div>
     </div>
-    <div v-show="appendIcon" class="text-lg col-start-3 pt-4 pl-1">
-        <c-svg-icon :icon="appendIcon" @click="$emit('click:append')" size="medium" class="text-gray-500 cursor-pointer" />
+    <div v-show="appendIcon" class="my-auto text-lg col-start-3 pt-1.5 pl-1">
+        <c-svg-icon :icon="appendIcon" @click="$emit('click:append')" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
     </div>
     <div v-if="isError" class="text-xs text-[var(--jupiter-danger-text)] pt-1 col-start-2">
         <p v-for="(msg,index) in formatedErrorMessage" :key="index">

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -80,7 +80,6 @@ const isError = computed(() => {
 const fieldClass = computed(() => {
     const base = [
         'group peer relative col-start-2 flex items-center w-full appearance-none focus:outline-none focus:ring-0 opacity-100',
-        props.label === '' ? 'placeholder:opacity-100': '',
         props.readonly ? 'focus-within:border-gray-900' : 'focus-within:border-blue-600',
         isError.value 
         ? 'border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)] text-[var(--jupiter-danger-text)] placeholder:text-[var(--jupiter-danger-text)] placeholder:opacity-0 focus:placeholder:opacity-50' 

--- a/src/components/form/CSelect.vue
+++ b/src/components/form/CSelect.vue
@@ -81,7 +81,7 @@ const fieldClass = computed(() => {
     const base = [
         'peer relative col-start-2 flex items-center w-full appearance-none focus:outline-none focus:ring-0 opacity-100',
     ]
-    if(isError.value) base.push('border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)]')
+    if(isError.value) base.push('border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-outline-focus)]')
     if(!isError.value && props.readonly) base.push('focus-within:border-gray-900 border-gray-300') 
     if(!isError.value && !props.readonly) base.push('focus-within:border-blue-600 border-gray-300')
     if(props.variant === 'filled') base.push('min-h-[2.7rem] rounded-t-lg rounded-b-none px-2.5 bg-gray-50 border-0 border-b-2')
@@ -111,19 +111,19 @@ const labelClass = computed(() => {
     if(isError.value ) base.push('text-[var(--jupiter-danger-text)]')
     if(!isError.value ) base.push('text-gray-500 peer-focus:text-blue-600')
     if(props.variant === 'filled') base.push(
-        '-translate-y-4 top-4 z-10 peer-focus:-translate-y-4',
+        '-translate-y-4 top-4 peer-focus:-translate-y-4',
         !props.modelValue || !props.modelValue.length 
         ? 'scale-100 translate-y-0' 
         : props.placeholder ? 'scale-75' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0'
         )
     if(props.variant === 'outlined') base.push(
-        '-translate-y-4 top-4 z-10 peer-focus:-translate-y-4',
+        '-translate-y-4 top-4 peer-focus:-translate-y-4',
         !props.modelValue || !props.modelValue.length 
         ? 'scale-100 translate-y-0' 
         : props.placeholder ? 'scale-75' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-0'
         )
     if(props.variant === 'underlined') base.push(
-        '-translate-y-5 top-3 z-10 peer-focus:left-0 peer-focus:-translate-y-5',
+        '-translate-y-5 top-3 peer-focus:left-0 peer-focus:-translate-y-5',
         !props.modelValue || !props.modelValue.length 
         ? 'scale-100 translate-y-0' 
         : props.placeholder ? 'scale-75' : 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0'

--- a/src/components/form/CTextField.story.vue
+++ b/src/components/form/CTextField.story.vue
@@ -361,6 +361,7 @@ const error : {
 | --- | --- | --- | --- |
 | appendIcon | string | undefined | 入力フォームの右外側に表示させるiconを指定します |
 | appendInnerIcon | string | undefined | 入力フォームの右内側に表示させるiconを指定します |
+| clearable | boolean | false | 選択した値をクリアするボタンを追加する場合は指定します |
 | disabled | boolean | false | 非活性にする場合は指定します |
 | error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
 | errorMessage | string/string[] | '' | コンポーネントをエラー状態にし、表示するメッセージを指定します|

--- a/src/components/form/CTextField.story.vue
+++ b/src/components/form/CTextField.story.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import {reactive} from "vue";
-import { mdiEye, mdiEyeOff } from "@mdi/js";
+import {logEvent} from "histoire/client";
+import { mdiEye, mdiEyeOff, mdiComment } from "@mdi/js";
 import CTextField from "@/components/form/CTextField.vue";
 import CBox from "@/components/layout/CBox.vue";
+import CStack from "@/components/layout/CStack.vue";
 
 const filled: {
     modelValue: string
@@ -51,9 +53,31 @@ const password : {
     show: boolean
 } = reactive({
     modelValue: 'password',
-    label: 'emailのラベル',
+    label: 'passwordのラベル',
     placeholder: '',
     show: false,
+})
+
+const clearable : {
+    modelValue: string
+    label: string
+    placeholder: string
+    clearable: boolean
+    variant: 'filled'|'outlined'|'underlined'
+} = reactive({
+    modelValue: 'バツをクリックするとクリアされます',
+    label: 'clearable',
+    placeholder: '',
+    clearable: true,
+    variant: 'filled',
+})
+
+const icons : {
+    modelValue: string
+    variant: 'filled'|'outlined'|'underlined'
+} = reactive({
+    modelValue: '',
+    variant: 'filled',
 })
 
 const disabled : {
@@ -178,7 +202,77 @@ const error : {
                 id="password"
             />
         </c-box>
+    </Variant>  
+
+    <Variant title="clearable" auto-props-disabled>
+        <c-box padding="medium">
+            <c-text-field 
+                v-model="clearable.modelValue"
+                :label="clearable.label"
+                :placeholder="clearable.placeholder"
+                :clearable="clearable.clearable"
+                :variant="clearable.variant"
+            />
+        </c-box>
+        <template #controls>
+            <HstSelect
+            v-model="clearable.variant"
+            title="variant"
+            :options="[
+                {value: 'filled', label: 'filled'},
+                {value: 'outlined', label: 'outlined'},
+                {value: 'underlined', label: 'underlined'},
+            ]"
+            />
+        </template>
     </Variant>    
+
+    <Variant title="Icons" auto-props-disabled>
+        <c-box padding="medium">
+            <c-stack>
+                <c-text-field 
+                    v-model="icons.modelValue"
+                    label="prepend-icon"
+                    :variant="icons.variant"
+                    :prepend-icon="mdiComment"
+                    @click:prepend="logEvent('fire click:prepend', $event)"
+                />
+                <c-text-field 
+                    v-model="icons.modelValue"
+                    label="append-icon"
+                    :variant="icons.variant"
+                    :append-icon="mdiComment"
+                    @click:append="logEvent('fire click:append', $event)"
+                />
+                <c-text-field 
+                    v-model="icons.modelValue"
+                    label="prepend-inner-icon"
+                    :variant="icons.variant"
+                    :prepend-inner-icon="mdiComment"
+                    @click:prepend-inner="logEvent('fire click:prepend-inner', $event)"
+                />
+                <c-text-field 
+                    v-model="icons.modelValue"
+                    label="append-inner-icon"
+                    :variant="icons.variant"
+                    :append-inner-icon="mdiComment"
+                    @click:append-inner="logEvent('fire click:append-inner', $event)"
+                    clearable
+                />
+            </c-stack>
+        </c-box>
+        <template #controls>
+            <HstSelect
+            v-model="icons.variant"
+            title="variant"
+            :options="[
+                {value: 'filled', label: 'filled'},
+                {value: 'outlined', label: 'outlined'},
+                {value: 'underlined', label: 'underlined'},
+            ]"
+            />
+        </template>
+    </Variant>
 
     <Variant title="非活性" auto-props-disabled>
         <c-box padding="medium">
@@ -265,7 +359,8 @@ const error : {
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| appendIcon | string | undefined | iconを入力フォームの右に追加する場合は指定します |
+| appendIcon | string | undefined | 入力フォームの右外側に表示させるiconを指定します |
+| appendInnerIcon | string | undefined | 入力フォームの右内側に表示させるiconを指定します |
 | disabled | boolean | false | 非活性にする場合は指定します |
 | error | boolean | false | コンポーネントをエラー状態にする場合は指定します |
 | errorMessage | string/string[] | '' | コンポーネントをエラー状態にし、表示するメッセージを指定します|
@@ -275,7 +370,8 @@ const error : {
 | modelValue | string | '' | コンポーネントのv-model値です |
 | name | string | undefined | nameを指定します |
 | placeholder | string | '' | placeholderのメッセージを指定することができます |
-| prependIcon | string | undefined | iconを入力フォームの左に追加する場合は指定します |
+| prependIcon | string | undefined | 入力フォームの左外側に表示させるiconを指定します |
+| prependInnerIcon | string | undefined | 入力フォームの左内側に表示させるiconを指定します |
 | readonly | boolean | false | 読み取り専用にする場合は指定します |
 | type | 'text'/'email'/'password' | 'text' | inputのtype属性を選択します |
 | variant | 'filled'/'outlined'/'underlined' | 'filled' | コンポーネントに独自のスタイルを指定します |
@@ -291,7 +387,9 @@ const error : {
 | Name | Parameters | Description |
 | --- | --- | --- |
 | update:modelValue | - | コンポーネントのv-modelが変更されたときに発行されるイベントです |
-| click:append | - | 入力フォームの右側に表示されたアイコンをクリックした時に発行されるイベントです |
-| click:prepend | - | 入力フォームの左側に表示されたアイコンをクリックした時に発行されるイベントです |
+| click:append | - | 入力フォームの右外側に表示されたアイコンをクリックした時に発行されるイベントです |
+| click:prepend | - | 入力フォームの左外側に表示されたアイコンをクリックした時に発行されるイベントです |
+| click:appendInner | - | 入力フォームの右内側に表示されたアイコンをクリックした時に発行されるイベントです |
+| click:prependInner | - | 入力フォームの左内側に表示されたアイコンをクリックした時に発行されるイベントです |
 
 </docs>

--- a/src/components/form/CTextField.vue
+++ b/src/components/form/CTextField.vue
@@ -127,11 +127,11 @@ const clear = () => {
 <template>
 <div class="relative w-auto grid grid-cols-[auto_1fr_auto] gap-y-1">
     <div v-show="prependIcon" class="text-lg col-start-1 pt-4 pr-1">
-        <c-svg-icon @click="$emit('click:prepend')" :icon="prependIcon" size="medium" class="cursor-pointer text-gray-500"/>
+        <c-svg-icon @click="$emit('click:prepend')" :icon="prependIcon" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
     </div>
     <div :class="fieldClass">
         <div v-show="prependInnerIcon" class="pt-2 pr-2 text-lg">
-            <c-svg-icon :icon="prependInnerIcon" @click="$emit('click:prependInner')" size="medium" class="text-gray-500 cursor-pointer" />
+            <c-svg-icon :icon="prependInnerIcon" @click="$emit('click:prependInner')" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
         </div>
         <div class="relative w-full">
             <input 
@@ -155,12 +155,12 @@ const clear = () => {
             <c-svg-icon :icon="mdiClose" @click="clear" class="text-gray-500 cursor-pointer" />
         </div>
         <div v-show="appendInnerIcon" class="pt-2 pl-1 text-lg">
-            <c-svg-icon :icon="appendInnerIcon" @click="$emit('click:appendInner')" size="medium" class="text-gray-500 cursor-pointer" />
+            <c-svg-icon :icon="appendInnerIcon" @click="$emit('click:appendInner')" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
         </div>
 
     </div>
     <div v-show="appendIcon" class="text-lg col-start-3 pt-4 pl-1">
-        <c-svg-icon :icon="appendIcon" @click="$emit('click:append')" size="medium" class="text-gray-500 cursor-pointer" />
+        <c-svg-icon :icon="appendIcon" @click="$emit('click:append')" size="medium" class=" cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
     </div>
     <div v-show="isError" class="text-xs text-[var(--jupiter-danger-text)] col-start-2">
         <p v-for="(msg,index) in formatedErrorMessage" :key="index">

--- a/src/components/form/CTextField.vue
+++ b/src/components/form/CTextField.vue
@@ -65,7 +65,7 @@ const fieldClass = computed(() => {
     const base = [
         'peer w-full col-start-2 flex items-center appearance-none text-gray-900 focus:outline-none focus:ring-0 opacity-100',
     ]
-    if(isError.value) base.push('border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)]')
+    if(isError.value) base.push('border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-outline-focus)]')
     if(!isError.value && props.readonly) base.push('focus-within:border-gray-900 border-gray-300') 
     if(!isError.value && !props.readonly) base.push('focus-within:border-blue-600 border-gray-300')
 

--- a/src/components/form/CTextField.vue
+++ b/src/components/form/CTextField.vue
@@ -64,11 +64,11 @@ const isError = computed(() => {
 const fieldClass = computed(() => {
     const base = [
         'peer w-full col-start-2 flex items-center appearance-none text-gray-900 focus:outline-none focus:ring-0 opacity-100',
-        props.readonly ? 'focus-within:border-gray-900' : 'focus-within:border-blue-600',
-        isError.value 
-        ? 'border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)] text-[var(--jupiter-danger-text)] placeholder:text-[var(--jupiter-danger-text)] placeholder:opacity-0 focus:placeholder:opacity-50' 
-        : 'placeholder:text-gray-400 placeholder:opacity-0 focus:placeholder:opacity-100 border-gray-300',
     ]
+    if(isError.value) base.push('border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)]')
+    if(!isError.value && props.readonly) base.push('focus-within:border-gray-900 border-gray-300') 
+    if(!isError.value && !props.readonly) base.push('focus-within:border-blue-600 border-gray-300')
+
     if(props.variant === 'filled') base.push('rounded-t-lg rounded-b-none px-2.5 bg-gray-50 border-0 border-b-2')
     if(props.variant === 'outlined') base.push('px-2.5 bg-transparent rounded-lg border')
     if(props.variant === 'underlined') base.push('rounded-none px-0 bg-transparent border-0 border-b-2')
@@ -77,14 +77,14 @@ const fieldClass = computed(() => {
 })
 const inputClass = computed(() => {
     const base = [
-        'peer w-full appearance-none text-gray-900 focus:outline-none focus:ring-0 disabled:text-gray-500 opacity-100 bg-transparent',
-        props.label === '' 
-        ? 'placeholder:opacity-100'
-        : !props.modelValue ? 'placeholder:opacity-0 focus:placeholder:opacity-100' : 'placeholder:opacity-0',
-        props.variant === 'filled' ? 'pt-4 pb-1' : '',
-        props.variant === 'outlined' ? 'pt-4 pb-1.5' : '',
-        props.variant === 'underlined' ? 'pt-2.5 pb-1' : '',        
+        'peer w-full appearance-none text-gray-900 focus:outline-none focus:ring-0 disabled:text-gray-500 read-only:text-gray-500 opacity-100 bg-transparent',
     ]
+    if(!props.label) base.push('placeholder:opacity-100')
+    if(props.label && !props.modelValue) base.push('placeholder:opacity-0 focus:placeholder:opacity-100')
+    if(props.label && props.modelValue) base.push('placeholder:opacity-0')
+    if(props.variant === 'filled') base.push('pt-4 pb-1')
+    if(props.variant === 'outlined') base.push('pt-4 pb-1.5')
+    if(props.variant === 'underlined') base.push('pt-2.5 pb-1')
 
     return base
 })
@@ -95,19 +95,14 @@ const labelClass = computed(() => {
     ]
     if(isError.value) base.push('text-[var(--jupiter-danger-text)]')
     if(!isError.value) base.push('text-gray-500 peer-read-only:peer-focus:text-gray-900 peer-focus:text-blue-600')
-    if(props.variant === 'filled') base.push(
-        '-translate-y-4 top-4 left-0 peer-focus:-translate-y-4',
-        props.modelValue ? 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0' : 'scale-100 translate-y-0'
-        )
-    if(props.variant === 'outlined') base.push(
-        '-translate-y-4 top-4 left-0 peer-focus:-translate-y-4',
-        props.modelValue ? 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0' : 'scale-100 translate-y-0'
-        )
-    if(props.variant === 'underlined') base.push(
-        '-translate-y-5 top-3 left-0 peer-focus:left-0 peer-focus:-translate-y-5',
-        props.modelValue ? 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0' : 'scale-100 translate-y-0'
-        )
-
+    if(props.variant === 'filled') base.push('-translate-y-4 top-4 left-0 peer-focus:-translate-y-4',)
+    if(props.variant === 'filled' && props.modelValue) base.push('scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
+    if(props.variant === 'outlined') base.push('-translate-y-4 top-4 left-0 peer-focus:-translate-y-4')
+    if(props.variant === 'outlined' && props.modelValue) base.push('scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
+    if(props.variant === 'underlined') base.push('-translate-y-5 top-3 left-0 peer-focus:left-0 peer-focus:-translate-y-5')
+    if(props.variant === 'underlined' && props.modelValue) base.push('scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
+    if(!props.modelValue) base.push('scale-100 translate-y-0')
+    
     return base
 })
 
@@ -126,11 +121,11 @@ const clear = () => {
 
 <template>
 <div class="relative w-auto grid grid-cols-[auto_1fr_auto] gap-y-1">
-    <div v-show="prependIcon" class="text-lg col-start-1 pt-4 pr-1">
+    <div v-show="prependIcon" class="my-auto text-lg col-start-1 pt-1.5 pr-1">
         <c-svg-icon @click="$emit('click:prepend')" :icon="prependIcon" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
     </div>
     <div :class="fieldClass">
-        <div v-show="prependInnerIcon" class="pt-2 pr-2 text-lg">
+        <div v-show="prependInnerIcon" class="my-auto pt-2 pr-2 text-lg">
             <c-svg-icon :icon="prependInnerIcon" @click="$emit('click:prependInner')" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
         </div>
         <div class="relative w-full">
@@ -154,12 +149,12 @@ const clear = () => {
         <div v-show="clearIconDisplay" class="pt-2">
             <c-svg-icon :icon="mdiClose" @click="clear" class="text-gray-500 cursor-pointer" />
         </div>
-        <div v-show="appendInnerIcon" class="pt-2 pl-1 text-lg">
+        <div v-show="appendInnerIcon" class="my-auto pt-2 pl-1 text-lg">
             <c-svg-icon :icon="appendInnerIcon" @click="$emit('click:appendInner')" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
         </div>
 
     </div>
-    <div v-show="appendIcon" class="text-lg col-start-3 pt-4 pl-1">
+    <div v-show="appendIcon" class="my-auto text-lg col-start-3 pt-1.5 pl-1">
         <c-svg-icon :icon="appendIcon" @click="$emit('click:append')" size="medium" class=" cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
     </div>
     <div v-show="isError" class="text-xs text-[var(--jupiter-danger-text)] col-start-2">

--- a/src/components/form/CTextarea.vue
+++ b/src/components/form/CTextarea.vue
@@ -68,8 +68,8 @@ const fieldClass = computed(() => {
         'group peer col-start-2 flex items-start w-full',
     ]
     if(isError.value) base.push('border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)]' )
-    if(!isError.value) base.push(props.readonly? 'focus-within:border-gray-900' : 'border-gray-300 focus-within:border-blue-600')
-
+    if(!isError.value && props.readonly) base.push('focus-within:border-gray-900')
+    if(!isError.value && !props.readonly) base.push('border-gray-300 focus-within:border-blue-600')
     if(props.variant === 'filled') base.push('rounded-t-lg rounded-b-none bg-gray-50 border-0 border-b-2')
     if(props.variant === 'outlined') base.push('bg-transparent rounded-lg border')
     if(props.variant === 'underlined') base.push('rounded-none bg-transparent border-0 border-b-2')
@@ -79,10 +79,11 @@ const fieldClass = computed(() => {
 
 const textareaClass = computed(() => {
     const base = [
-        'peer block w-full appearance-none bg-transparent focus:outline-none focus:ring-0 disabled:text-gray-500 opacity-100',
-        props.label === '' ? 'placeholder:opacity-100': '',
-        isError.value ? 'placeholder:text-[var(--jupiter-danger-text)] placeholder:opacity-0 focus:placeholder:opacity-50' : 'text-gray-900 read-only:text-gray-500 placeholder:text-gray-400 placeholder:opacity-0 focus:placeholder:opacity-100',
+        'peer block w-full appearance-none bg-transparent focus:outline-none focus:ring-0 disabled:text-gray-500 read-only:text-gray-500 opacity-100',
     ]
+    if(!props.label) base.push('placeholder:opacity-100')
+    if(props.label && !props.modelValue) base.push('placeholder:opacity-0 focus:placeholder:opacity-100')
+    if(props.label && props.modelValue) base.push('placeholder:opacity-0')
     if(props.variant === 'filled') base.push('min-h-[2.7rem] px-2.5 pb-1 pt-4')
     if(props.variant === 'outlined') base.push('min-h-[2.8rem] px-2.5 pb-1.5 pt-4')
     if(props.variant === 'underlined') base.push('min-h-[2.3rem] pt-2.5 pb-1 pl-1')
@@ -96,19 +97,13 @@ const labelClass = computed(() => {
     ]
     if(isError.value) base.push('text-[var(--jupiter-danger-text)]')
     if(!isError.value) base.push('text-gray-500 peer-read-only:peer-focus:text-gray-900 peer-focus:text-blue-600')
-    if(props.variant === 'filled') base.push(
-        '-translate-y-4 top-4 z-10 left-2.5 peer-focus:-translate-y-4',
-        props.modelValue ? 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0' : 'scale-100 translate-y-0'
-        )
-    if(props.variant === 'outlined') base.push(
-        '-translate-y-4 top-4 z-10 px-2 peer-focus:px-2 peer-focus:-translate-y-4 left-1 top-4',
-        props.modelValue ? 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0' : 'scale-100 translate-y-0'
-        )
-    if(props.variant === 'underlined') base.push(
-        '-translate-y-4 top-3 z-10 pl-1 peer-focus:left-0 peer-focus:-translate-y-4',
-        props.modelValue ? 'scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0' : 'scale-100 translate-y-0'
-        )
-
+    if(props.variant === 'filled') base.push('-translate-y-4 top-4 z-10 left-2.5 peer-focus:-translate-y-4')
+    if(props.variant === 'filled' && props.modelValue) base.push('scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
+    if(props.variant === 'outlined') base.push('-translate-y-4 top-4 z-10 px-2 peer-focus:px-2 peer-focus:-translate-y-4 left-1 top-4')
+    if(props.variant === 'outlined' && props.modelValue) base.push('scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
+    if(props.variant === 'underlined') base.push('-translate-y-4 top-3 z-10 pl-1 peer-focus:left-0 peer-focus:-translate-y-4')
+    if(props.variant === 'underlined' && props.modelValue) base.push('scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
+    if(!props.modelValue) base.push('scale-100 translate-y-0')
     return base
 })
 
@@ -126,11 +121,11 @@ const clear = () => {
 <template>
 <div class="grid grid-cols-[auto_1fr_auto] gap-y-1">
     <div v-show="prependIcon" class="text-lg col-start-1 pt-4 pr-1">
-        <c-svg-icon :icon="prependIcon" @click="$emit('click:prepend')" size="medium" class="text-gray-500 cursor-pointer" />
+        <c-svg-icon :icon="prependIcon" @click="$emit('click:prepend')" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
     </div>
     <div :class="fieldClass">
         <div v-show="prependInnerIcon" class="pl-2 pt-4 text-lg">
-            <c-svg-icon :icon="prependInnerIcon" @click="$emit('click:prependInner')" size="medium" class="text-gray-500 cursor-pointer" />
+            <c-svg-icon :icon="prependInnerIcon" @click="$emit('click:prependInner')" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
         </div>
         <div class="relative w-full">
             <textarea
@@ -151,11 +146,11 @@ const clear = () => {
             <c-svg-icon v-show="clearIconDisplay" :icon="mdiClose" @click="clear" class="text-gray-500 peer-disabled:hidden peer-read-only:hidden cursor-pointer" />
         </div>
         <div v-show="appendInnerIcon" class="px-2 pt-4 text-lg">
-            <c-svg-icon :icon="appendInnerIcon" @click="$emit('click:appendInner')" size="medium" class="text-gray-500 cursor-pointer" />
+            <c-svg-icon :icon="appendInnerIcon" @click="$emit('click:appendInner')" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
         </div>
     </div>
     <div v-show="appendIcon" class="text-lg col-start-3 pt-4 pl-1">
-        <c-svg-icon :icon="appendIcon" @click="$emit('click:append')" size="medium" class="text-gray-500 cursor-pointer" />
+        <c-svg-icon :icon="appendIcon" @click="$emit('click:append')" size="medium" class="cursor-pointer" :class="error?'text-[var(--jupiter-danger-text)]':'text-gray-500'"/>
     </div>
     <div v-show="isError" class="text-xs text-[var(--jupiter-danger-text)] col-start-2">
         <p v-for="(msg,index) in formatedErrorMessage" :key="index">

--- a/src/components/form/CTextarea.vue
+++ b/src/components/form/CTextarea.vue
@@ -67,7 +67,7 @@ const fieldClass = computed(() => {
     const base = [
         'group peer col-start-2 flex items-start w-full',
     ]
-    if(isError.value) base.push('border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-border)]' )
+    if(isError.value) base.push('border-[var(--jupiter-danger-border)] focus-within:border-[var(--jupiter-danger-outline-focus)]' )
     if(!isError.value && props.readonly) base.push('focus-within:border-gray-900')
     if(!isError.value && !props.readonly) base.push('border-gray-300 focus-within:border-blue-600')
     if(props.variant === 'filled') base.push('rounded-t-lg rounded-b-none bg-gray-50 border-0 border-b-2')
@@ -97,11 +97,11 @@ const labelClass = computed(() => {
     ]
     if(isError.value) base.push('text-[var(--jupiter-danger-text)]')
     if(!isError.value) base.push('text-gray-500 peer-read-only:peer-focus:text-gray-900 peer-focus:text-blue-600')
-    if(props.variant === 'filled') base.push('-translate-y-4 top-4 z-10 left-2.5 peer-focus:-translate-y-4')
+    if(props.variant === 'filled') base.push('-translate-y-4 top-4 left-2.5 peer-focus:-translate-y-4')
     if(props.variant === 'filled' && props.modelValue) base.push('scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
-    if(props.variant === 'outlined') base.push('-translate-y-4 top-4 z-10 px-2 peer-focus:px-2 peer-focus:-translate-y-4 left-1 top-4')
+    if(props.variant === 'outlined') base.push('-translate-y-4 top-4 px-2 peer-focus:px-2 peer-focus:-translate-y-4 left-1 top-4')
     if(props.variant === 'outlined' && props.modelValue) base.push('scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
-    if(props.variant === 'underlined') base.push('-translate-y-4 top-3 z-10 pl-1 peer-focus:left-0 peer-focus:-translate-y-4')
+    if(props.variant === 'underlined') base.push('-translate-y-4 top-3 pl-1 peer-focus:left-0 peer-focus:-translate-y-4')
     if(props.variant === 'underlined' && props.modelValue) base.push('scale-75 peer-placeholder-shown:scale-100 peer-placeholder-shown:translate-y-0')
     if(!props.modelValue) base.push('scale-100 translate-y-0')
     return base

--- a/src/variables.css
+++ b/src/variables.css
@@ -60,7 +60,7 @@
     --jupiter-danger-text: #e11d48;
     --jupiter-danger-outline: #e11d48;
     --jupiter-danger-outline-hover: #c1173c;
-    --jupiter-danger-outline-focus: #e11d48;
+    --jupiter-danger-outline-focus: #c1173c;
 
     /* warning */
     --jupiter-warning-background: #facc15;


### PR DESCRIPTION
#79 

以下フォーム部品に、アイコンを表示させるpropsを用意しました。

- TextField
- Select
- Autocomplete

## Autocomplete
<img width="496" alt="スクリーンショット 2023-03-30 16 23 49" src="https://user-images.githubusercontent.com/101681088/228761694-cfbd36d4-f5c2-4417-9a5a-051f88c9b05c.png">

## Select
<img width="504" alt="スクリーンショット 2023-03-30 16 23 57" src="https://user-images.githubusercontent.com/101681088/228761707-fb56df71-7fa6-488d-aa21-dd6948f2217a.png">

## TextField
<img width="505" alt="スクリーンショット 2023-03-30 16 24 12" src="https://user-images.githubusercontent.com/101681088/228761713-05654ddd-05cd-41e8-a62b-ec05473d54d8.png">

## 各ブラウザでの確認済み

- Google Chrome
- FireFox
- Edge
- Safari
- Android Emulator
- iPhone Simulator
